### PR TITLE
Add FTS5 search support and migrate existing SQLite stores

### DIFF
--- a/memory_system/core/store.py
+++ b/memory_system/core/store.py
@@ -175,6 +175,32 @@ class SQLiteMemoryStore:
             conn = await self._acquire()
             try:
                 await conn.execute(self._CREATE_SQL)
+                # Ensure FTS virtual table and triggers exist
+                await conn.executescript(
+                    """
+                    CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(text);
+                    CREATE TRIGGER IF NOT EXISTS memories_ai AFTER INSERT ON memories BEGIN
+                        INSERT INTO memories_fts(rowid, text) VALUES (new.rowid, new.text);
+                    END;
+                    CREATE TRIGGER IF NOT EXISTS memories_ad AFTER DELETE ON memories BEGIN
+                        DELETE FROM memories_fts WHERE rowid = old.rowid;
+                    END;
+                    CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE ON memories BEGIN
+                        DELETE FROM memories_fts WHERE rowid = old.rowid;
+                        INSERT INTO memories_fts(rowid, text) VALUES (new.rowid, new.text);
+                    END;
+                    """
+                )
+                # Migration: backfill FTS table if empty or out of sync
+                cur = await conn.execute("SELECT count(*) FROM memories")
+                mem_count = (await cur.fetchone())[0]
+                cur = await conn.execute("SELECT count(*) FROM memories_fts")
+                fts_count = (await cur.fetchone())[0]
+                if mem_count != fts_count:
+                    await conn.execute("DELETE FROM memories_fts")
+                    await conn.execute(
+                        "INSERT INTO memories_fts(rowid, text) SELECT rowid, text FROM memories"
+                    )
                 await conn.commit()
                 self._initialised = True
             finally:
@@ -271,29 +297,37 @@ class SQLiteMemoryStore:
         metadata_filters: Optional[Dict[str, Any]] = None,
         limit: int = 20,
     ) -> List[Memory]:
-        """Simple LIKE + JSON1 metadata search (no vectors here)."""
+        """Full-text + JSON1 metadata search (no vectors here)."""
         await self.initialise()
         conn = await self._acquire()
         try:
-            # build WHERE clause
-            clauses: List[str] = []
             params: List[Any] = []
             if text_query:
-                clauses.append("text LIKE ?")
-                params.append(f"%{text_query}%")
-            if metadata_filters:
-                for key, val in metadata_filters.items():
-                    clauses.append("json_extract(metadata, ?) = ?")
-                    params.extend([f"$.{key}", val])
-
-            # construct final SQL
-            sql = "SELECT id, text, created_at, importance, valence, emotional_intensity, metadata FROM memories"
-            if clauses:
-                sql += " WHERE " + " AND ".join(clauses)
-            sql += " ORDER BY created_at DESC LIMIT ?"
+                sql = (
+                    "SELECT m.id, m.text, m.created_at, m.importance, m.valence, "
+                    "m.emotional_intensity, m.metadata "
+                    "FROM memories_fts JOIN memories m ON m.rowid = memories_fts.rowid "
+                    "WHERE memories_fts MATCH ?"
+                )
+                params.append(text_query)
+                if metadata_filters:
+                    for key, val in metadata_filters.items():
+                        sql += " AND json_extract(m.metadata, ?) = ?"
+                        params.extend([f"$.{key}", val])
+                sql += " ORDER BY bm25(memories_fts) LIMIT ?"
+            else:
+                clauses: List[str] = []
+                if metadata_filters:
+                    for key, val in metadata_filters.items():
+                        clauses.append("json_extract(metadata, ?) = ?")
+                        params.extend([f"$.{key}", val])
+                sql = (
+                    "SELECT id, text, created_at, importance, valence, emotional_intensity, metadata FROM memories"
+                )
+                if clauses:
+                    sql += " WHERE " + " AND ".join(clauses)
+                sql += " ORDER BY created_at DESC LIMIT ?"
             params.append(limit)
-
-            # execute and map results
             cursor = await conn.execute(sql, params)
             rows = await cursor.fetchall()
             return [self._row_to_memory(r) for r in rows]

--- a/tests/test_sqlite_store_extended.py
+++ b/tests/test_sqlite_store_extended.py
@@ -1,8 +1,8 @@
 import asyncio
 import json
 from pathlib import Path
-from typing import Any, Dict, List
 
+import aiosqlite
 import pytest
 
 from memory_system.core.store import Memory, SQLiteMemoryStore
@@ -67,3 +67,63 @@ async def test_search_no_results(tmp_path: Path) -> None:
     store = SQLiteMemoryStore(str(tmp_path / "db.sqlite"))
     results = await store.search("nothing")
     assert results == []
+
+
+@pytest.mark.asyncio
+async def test_fts_prefix_query(tmp_path: Path) -> None:
+    store = SQLiteMemoryStore(str(tmp_path / "db.sqlite"))
+    await store.add(Memory.new("prefixmatch"))
+    results = await store.search("pref*")
+    assert len(results) == 1
+    assert results[0].text == "prefixmatch"
+
+
+@pytest.mark.asyncio
+async def test_migration_creates_fts(tmp_path: Path) -> None:
+    db_path = tmp_path / "db.sqlite"
+    # create legacy schema without FTS
+    async with aiosqlite.connect(db_path.as_posix()) as conn:
+        await conn.execute(
+            """
+            CREATE TABLE memories (
+                id TEXT PRIMARY KEY,
+                text TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                importance REAL DEFAULT 0,
+                valence REAL DEFAULT 0,
+                emotional_intensity REAL DEFAULT 0,
+                metadata JSON
+            );
+            """
+        )
+        mem = Memory.new("legacy text")
+        await conn.execute(
+            "INSERT INTO memories (id, text, created_at, importance, valence, emotional_intensity, metadata)"
+            " VALUES (?, ?, ?, ?, ?, ?, json(?))",
+            (
+                mem.id,
+                mem.text,
+                mem.created_at.isoformat(),
+                mem.importance,
+                mem.valence,
+                mem.emotional_intensity,
+                json.dumps(mem.metadata) if mem.metadata else "null",
+            ),
+        )
+        await conn.commit()
+
+    store = SQLiteMemoryStore(db_path.as_posix())
+    results = await store.search("legacy")
+    assert results and results[0].text == "legacy text"
+
+    # ensure triggers keep FTS in sync
+    await store.add(Memory.new("new memory"))
+    res_new = await store.search("new")
+    assert any(r.text == "new memory" for r in res_new)
+
+    async with aiosqlite.connect(db_path.as_posix()) as conn:
+        cur = await conn.execute("SELECT count(*) FROM memories")
+        mem_count = (await cur.fetchone())[0]
+        cur = await conn.execute("SELECT count(*) FROM memories_fts")
+        fts_count = (await cur.fetchone())[0]
+        assert fts_count == mem_count


### PR DESCRIPTION
## Summary
- create FTS5 virtual table and triggers in SQLiteMemoryStore
- switch text search to use FTS `MATCH` queries
- backfill FTS table for existing databases and add tests

## Testing
- `pre-commit run --files memory_system/core/store.py tests/test_sqlite_store_extended.py` *(failed: command not found)*
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit)*
- `pytest tests/test_sqlite_store_extended.py` *(failed: ModuleNotFoundError: No module named 'aiosqlite')*
- `pip install aiosqlite` *(failed: Could not find a version that satisfies the requirement aiosqlite)*

------
https://chatgpt.com/codex/tasks/task_e_6895dbf98f5c8325aa0ae68f87f64fd2