### PR TITLE
Refactor embedding terminology

### DIFF
--- a/memory_system/core/embedding.py
+++ b/memory_system/core/embedding.py
@@ -56,7 +56,7 @@ class EmbeddingJob:
 class EmbeddingService:
     """Thread-safe, cache-aware embedding service.
 
-    Public API consists of the `encode` method (async) and a few internal helpers.
+    Public API consists of the `embed_text` method (async) and a few internal helpers.
     All heavy lifting happens in a single background thread to keep the asyncio event loop responsive.
     """
 
@@ -155,13 +155,13 @@ class EmbeddingService:
             # Process batch outside the lock
             try:
                 texts = [job.text for job in batch]
-                vectors = self._encode_direct(texts)  # synchronous call
-                for job, vec in zip(batch, vectors, strict=False):
+                embeddings = self._embed_direct(texts)  # synchronous call
+                for job, embedding in zip(batch, embeddings, strict=False):
                     if not job.future.done():
                         loop = job.future.get_loop()
                         loop.call_soon_threadsafe(
                             job.future.set_result,
-                            np.asarray(vec),
+                            np.asarray(embedding),
                         )
             except Exception as exc:
                 MET_ERRORS_TOTAL.labels(type="embedding", component="batch_loop").inc()
@@ -176,19 +176,19 @@ class EmbeddingService:
 
     # Public API
 
-    async def encode(self, text: str | Sequence[str]) -> np.ndarray:
-        """Return a vector embedding for the given text (string or sequence of strings)."""
+    async def embed_text(self, text: str | Sequence[str]) -> np.ndarray:
+        """Return an embedding for the given text (string or sequence of strings)."""
         if isinstance(text, str):
             # Single text -> returns shape (1, dim) array
-            return await self._encode_single(text)
+            return await self._embed_single(text)
         else:
             # Sequence of texts -> returns shape (n, dim) array
-            return await self._encode_multi(list(text))
+            return await self._embed_multi(list(text))
 
     # Internal async helpers
 
-    async def _encode_single(self, text: str) -> np.ndarray:
-        """Encode a single string into a 1 x dim embedding vector (as numpy array)."""
+    async def _embed_single(self, text: str) -> np.ndarray:
+        """Embed a single string into a 1 x dim embedding vector (as numpy array)."""
         if not text:
             raise ValueError("text must not be empty")
         # Attempt cache lookup first
@@ -210,30 +210,30 @@ class EmbeddingService:
             EMBEDDING_QUEUE_LENGTH.set(len(self._queue))
             self._queue_condition.notify()
         try:
-            vec = await asyncio.wait_for(future, timeout=30.0)
+            embedding = await asyncio.wait_for(future, timeout=30.0)
         except TimeoutError:
             future.cancel()
             raise EmbeddingError("Embedding timed out") from None
         # Cache the new embedding result for future reuse
-        self.cache.put(key, vec)
-        return vec.reshape(1, -1)
+        self.cache.put(key, embedding)
+        return embedding.reshape(1, -1)
 
-    async def _encode_multi(self, texts: list[str]) -> np.ndarray:
-        """Encode a list of texts into an array of embeddings."""
+    async def _embed_multi(self, texts: list[str]) -> np.ndarray:
+        """Embed a list of texts into an array of embeddings."""
         # For multiple texts, we can process them directly (and possibly cache each)
-        vectors = []
+        embeddings = []
         for text in texts:
-            vec = await self._encode_single(text)
-            vectors.append(vec)  # each vec is 1 x dim
+            embedding = await self._embed_single(text)
+            embeddings.append(embedding)  # each embedding is 1 x dim
         # Concatenate results into one array
-        return np.vstack(vectors)
+        return np.vstack(embeddings)
 
-    def _encode_direct(self, texts: list[str]) -> np.ndarray:
-        """Directly encode a batch of texts (runs in background thread)."""
+    def _embed_direct(self, texts: list[str]) -> np.ndarray:
+        """Directly embed a batch of texts (runs in background thread)."""
         if self._model is None:
             raise EmbeddingError("Embedding model is not loaded")
-        vec = self._model.encode(texts)
-        return np.asarray(vec, dtype=np.float32)
+        embedding = self._model.encode(texts)
+        return np.asarray(embedding, dtype=np.float32)
 
     def _cache_key(self, text: str) -> str:
         """Compute a cache key for a given text input."""

--- a/memory_system/core/enhanced_store.py
+++ b/memory_system/core/enhanced_store.py
@@ -134,17 +134,17 @@ class EnhancedMemoryStore:
     async def semantic_search(
         self,
         *,
-        vector: list[float],
+        embedding: list[float],
         k: int = 5,
         return_distance: bool = False,
         ef_search: int | None = None,
     ) -> list[Any]:
-        """Perform a semantic vector search.
+        """Perform a semantic embedding search.
 
         Parameters
         ----------
-        vector:
-            Query vector.
+        embedding:
+            Query embedding.
         k:
             Number of nearest neighbours to return.
         return_distance:
@@ -157,9 +157,9 @@ class EnhancedMemoryStore:
         -------
         list[Any]
             A list of memories, optionally paired with their distance from the
-            query vector.
+            query embedding.
         """
-        ids, dists = self._index.search(np.asarray(vector, dtype=np.float32), k=k, ef_search=ef_search)
+        ids, dists = self._index.search(np.asarray(embedding, dtype=np.float32), k=k, ef_search=ef_search)
         results: list[Any] = []
         for _id, dist in zip(ids, dists, strict=False):
             mem = await self._store.get(_id)

--- a/memory_system/core/maintenance.py
+++ b/memory_system/core/maintenance.py
@@ -25,7 +25,7 @@ from memory_system.core.store import Memory, SQLiteMemoryStore
 
 
 def _cos_sim(a: np.ndarray, b: np.ndarray) -> float:
-    """Cosine similarity for two 1D vectors (assumed L2-normalized)."""
+    """Cosine similarity for two 1D embeddings (assumed L2-normalized)."""
     return float(np.dot(a, b))
 
 
@@ -113,12 +113,12 @@ async def consolidate_store(
 
     # Batch embeddings (faster than per-item).
     texts = [m.text for m in all_mems]
-    vecs = embed_text(texts)  # shape: (N, D)
-    if isinstance(vecs, np.ndarray) and vecs.ndim == 1:
-        vecs = vecs.reshape(1, -1)
-    assert vecs.shape[0] == len(all_mems), "Embedding batch size mismatch"
+    embeddings = embed_text(texts)  # shape: (N, D)
+    if isinstance(embeddings, np.ndarray) and embeddings.ndim == 1:
+        embeddings = embeddings.reshape(1, -1)
+    assert embeddings.shape[0] == len(all_mems), "Embedding batch size mismatch"
 
-    clusters = cluster_memories([vecs[i] for i in range(vecs.shape[0])], threshold)
+    clusters = cluster_memories([embeddings[i] for i in range(embeddings.shape[0])], threshold)
 
     created: List[Memory] = []
     ids_to_remove: List[str] = []
@@ -143,19 +143,19 @@ async def consolidate_store(
             },
         )
 
-        # Persist new memory & add vector to ANN index.
+        # Persist new memory & add embedding to ANN index.
         await store.add(summary_mem)
-        summary_vec = embed_text(summary_text)
-        if summary_vec.ndim == 1:
-            summary_vec = np.asarray([summary_vec], dtype=np.float32)
-        index.add_vectors([summary_mem.id], summary_vec.astype(np.float32, copy=False))
+        summary_embedding = embed_text(summary_text)
+        if summary_embedding.ndim == 1:
+            summary_embedding = np.asarray([summary_embedding], dtype=np.float32)
+        index.add_vectors([summary_mem.id], summary_embedding.astype(np.float32, copy=False))
         created.append(summary_mem)
 
         # Schedule originals for removal.
         ids_to_remove.extend(m.id for m in cluster_mems)
 
     if ids_to_remove:
-        # Remove vectors first, then rows.
+        # Remove embeddings first, then rows.
         index.remove_ids(ids_to_remove)
         for mid in ids_to_remove:
             try:

--- a/tests/test_benchmark_regression.py
+++ b/tests/test_benchmark_regression.py
@@ -23,7 +23,7 @@ from memory_system.core.enhanced_store import EnhancedMemoryStore
 from memory_system.utils.metrics import EMBEDDING_QUEUE_LENGTH
 
 DIM = UnifiedSettings.for_testing().model.vector_dim
-VECTOR = np.random.rand(DIM).astype("float32").tolist()
+EMBEDDING = np.random.rand(DIM).astype("float32").tolist()
 
 
 @pytest_asyncio.fixture(scope="session")
@@ -40,7 +40,7 @@ async def bench_store() -> AsyncGenerator[EnhancedMemoryStore, None]:
 def test_semantic_search_speed(benchmark: Any, bench_store: EnhancedMemoryStore) -> None:
     def _run() -> None:
         get_or_create_loop()
-        asyncio.run(bench_store.semantic_search(vector=VECTOR, k=5))
+        asyncio.run(bench_store.semantic_search(embedding=EMBEDDING, k=5))
 
     benchmark(_run)
 
@@ -51,11 +51,11 @@ async def test_embedding_queue_limit() -> None:
     cfg.performance.queue_max_size = 1
     svc = EmbeddingService(cfg.model.model_name, cfg)
     try:
-        t1 = asyncio.create_task(svc.encode("a"))
+        t1 = asyncio.create_task(svc.embed_text("a"))
         await asyncio.sleep(0.01)
         assert EMBEDDING_QUEUE_LENGTH._value.get() == 1
         with pytest.raises(EmbeddingError):
-            await svc.encode("b")
+            await svc.embed_text("b")
         await t1
     finally:
         svc.shutdown()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -339,56 +339,56 @@ class TestEnhancedEmbeddingService:
         assert service._batch_thread.is_alive()
 
     @pytest.mark.asyncio
-    async def test_encode_single_text(self, service: EnhancedEmbeddingService) -> None:
-        """Test encoding single text."""
+    async def test_embed_text_single_text(self, service: EnhancedEmbeddingService) -> None:
+        """Test embedding a single text."""
         text = "This is a test sentence."
-        expected = service._encode_direct([text])
-        result = await service.encode(text)
-        assert isinstance(result, np.ndarray)
-        np.testing.assert_array_equal(result, expected)
-        assert result.shape[0] == 1  # Single text
-        assert result.shape[1] > 0  # Non-zero dimensions
+        expected_embedding = service._embed_direct([text])
+        embedding = await service.embed_text(text)
+        assert isinstance(embedding, np.ndarray)
+        np.testing.assert_array_equal(embedding, expected_embedding)
+        assert embedding.shape[0] == 1  # Single text
+        assert embedding.shape[1] > 0  # Non-zero dimensions
 
     @pytest.mark.asyncio
-    async def test_encode_multiple_texts(self, service: EnhancedEmbeddingService) -> None:
-        """Test encoding multiple texts."""
+    async def test_embed_text_multiple_texts(self, service: EnhancedEmbeddingService) -> None:
+        """Test embedding multiple texts."""
         texts = ["First sentence.", "Second sentence.", "Third sentence."]
-        expected = service._encode_direct(texts)
-        result = await service.encode(texts)
-        assert isinstance(result, np.ndarray)
-        np.testing.assert_array_equal(result, expected)
-        assert result.shape[0] == 3  # Three texts
-        assert result.shape[1] > 0  # Non-zero dimensions
+        expected_embeddings = service._embed_direct(texts)
+        embeddings = await service.embed_text(texts)
+        assert isinstance(embeddings, np.ndarray)
+        np.testing.assert_array_equal(embeddings, expected_embeddings)
+        assert embeddings.shape[0] == 3  # Three texts
+        assert embeddings.shape[1] > 0  # Non-zero dimensions
 
     @pytest.mark.asyncio
-    async def test_encode_empty_text(self, service: EnhancedEmbeddingService) -> None:
-        """Test encoding empty text."""
+    async def test_embed_text_empty_text(self, service: EnhancedEmbeddingService) -> None:
+        """Test embedding empty text."""
         with pytest.raises((ValueError, RuntimeError)):  # Should raise some kind of error
-            await service.encode("")
+            await service.embed_text("")
 
     @pytest.mark.asyncio
-    async def test_encode_caching(self, service: EnhancedEmbeddingService) -> None:
-        """Test that encoding results are cached."""
+    async def test_embed_text_caching(self, service: EnhancedEmbeddingService) -> None:
+        """Test that embeddings are cached."""
         text = "This text will be cached."
         # First call
-        result1 = await service.encode(text)
+        embedding1 = await service.embed_text(text)
         # Second call should use cache
-        result2 = await service.encode(text)
-        np.testing.assert_array_equal(result1, result2)
+        embedding2 = await service.embed_text(text)
+        np.testing.assert_array_equal(embedding1, embedding2)
 
     @pytest.mark.asyncio
-    async def test_encode_timeout(self, service: EnhancedEmbeddingService) -> None:
-        """Test encoding timeout."""
-        # Mock a slow encoding operation
-        with patch.object(service, "_encode_direct") as mock_encode:
+    async def test_embed_text_timeout(self, service: EnhancedEmbeddingService) -> None:
+        """Test embedding timeout."""
+        # Mock a slow embedding operation
+        with patch.object(service, "_embed_direct") as mock_embed:
 
             def stub(_texts: list[str]) -> None:
                 asyncio.run(asyncio.sleep(0.1))
                 raise TimeoutError("operation timed out")
 
-            mock_encode.side_effect = stub
+            mock_embed.side_effect = stub
             with pytest.raises(EmbeddingError) as exc_info:
-                await service.encode("test text")
+                await service.embed_text("test text")
             assert "timed out" in str(exc_info.value).lower()
 
     def test_service_stats(self, service: EnhancedEmbeddingService) -> None:
@@ -428,8 +428,8 @@ class TestEnhancedEmbeddingService:
         # Should fall back to default model
         assert service.model_name == "all-MiniLM-L6-v2"
         # Should still work
-        result = await service.encode("test text")
-        assert isinstance(result, np.ndarray)
+        embedding = await service.embed_text("test text")
+        assert isinstance(embedding, np.ndarray)
         service.shutdown()
 
 
@@ -826,7 +826,7 @@ class TestCoreIntegration:
         try:
             # Test that both components can work together
             text = "Integration test text"
-            embedding = await embedding_service.encode(text)
+            embedding = await embedding_service.embed_text(text)
             assert isinstance(embedding, np.ndarray)
             await store.close()
             embedding_service.shutdown()

--- a/tests/test_enhanced_store.py
+++ b/tests/test_enhanced_store.py
@@ -29,7 +29,7 @@ async def store() -> AsyncGenerator[EnhancedMemoryStore, None]:
     await s.close()
 
 
-def _rand_vec(dim: int, seed: int = 42) -> list[float]:
+def _rand_embedding(dim: int, seed: int = 42) -> list[float]:
     rng = np.random.default_rng(seed)
     arr = rng.random(dim)
     if isinstance(arr, np.ndarray):
@@ -42,7 +42,7 @@ def _rand_vec(dim: int, seed: int = 42) -> list[float]:
 @pytest.mark.asyncio
 async def test_add_and_search(store: EnhancedMemoryStore) -> None:
     """Test adding a memory and searching for it."""
-    vec = _rand_vec(store.settings.model.vector_dim)
+    embedding = _rand_embedding(store.settings.model.vector_dim)
     ts = time.time()
 
     # 1) add a memory
@@ -51,7 +51,7 @@ async def test_add_and_search(store: EnhancedMemoryStore) -> None:
         role="user",
         tags=["demo"],
         importance=0.2,
-        embedding=vec,
+        embedding=embedding,
         created_at=ts,
         updated_at=ts,
         valence=0.0,
@@ -62,12 +62,12 @@ async def test_add_and_search(store: EnhancedMemoryStore) -> None:
     assert stats["total_memories"] == 1
     assert stats["index_size"] == 1
 
-    # 2) search using the same vector
-    res = await store.semantic_search(vector=vec, k=1)
+    # 2) search using the same embedding
+    res = await store.semantic_search(embedding=embedding, k=1)
     assert len(res) == 1
     assert res[0].text == "hello world"
 
-    res_with_dist = await store.semantic_search(vector=vec, k=1, return_distance=True)
+    res_with_dist = await store.semantic_search(embedding=embedding, k=1, return_distance=True)
     assert len(res_with_dist) == 1
     assert res_with_dist[0][0].text == "hello world"
     assert isinstance(res_with_dist[0][1], float)
@@ -76,25 +76,25 @@ async def test_add_and_search(store: EnhancedMemoryStore) -> None:
 @pytest.mark.asyncio
 async def test_search_empty_store(store: EnhancedMemoryStore) -> None:
     """Test searching when store is empty."""
-    vec = _rand_vec(store.settings.model.vector_dim)
-    res = await store.semantic_search(vector=vec, k=1)
+    embedding = _rand_embedding(store.settings.model.vector_dim)
+    res = await store.semantic_search(embedding=embedding, k=1)
     assert res == []
 
 
 @pytest.mark.asyncio
-async def test_invalid_vector_length(store: EnhancedMemoryStore) -> None:
-    """Test that invalid vector lengths are rejected."""
-    # vector shorter than required 384 elements
-    bad_vec = [0.1, 0.2, 0.3]
+async def test_invalid_embedding_length(store: EnhancedMemoryStore) -> None:
+    """Test that invalid embedding lengths are rejected."""
+    # embedding shorter than required 384 elements
+    bad_embedding = [0.1, 0.2, 0.3]
     with pytest.raises(ANNIndexError):
-        await store.semantic_search(vector=bad_vec, k=1)
+        await store.semantic_search(embedding=bad_embedding, k=1)
 
 
 # Optional extended check
 @pytest.mark.asyncio
-async def test_duplicate_vectors_rejected(store: EnhancedMemoryStore) -> None:
+async def test_duplicate_embeddings_rejected(store: EnhancedMemoryStore) -> None:
     dim = store.settings.model.vector_dim
-    v1 = _rand_vec(dim, seed=1)
+    v1 = _rand_embedding(dim, seed=1)
     now = time.time()
 
     # add the first memory

--- a/tests/test_enhanced_store_impl.py
+++ b/tests/test_enhanced_store_impl.py
@@ -47,10 +47,10 @@ async def test_enhanced_store_add_search_list_stats(tmp_path: Path) -> None:
         memories = await store.list_memories()
         assert len(memories) == 2
 
-        results = await store.semantic_search(vector=emb1, k=1)
+        results = await store.semantic_search(embedding=emb1, k=1)
         assert results and results[0].id == mem1.id
 
-        results_with_dist = await store.semantic_search(vector=emb1, k=1, return_distance=True)
+        results_with_dist = await store.semantic_search(embedding=emb1, k=1, return_distance=True)
         assert results_with_dist and results_with_dist[0][0].id == mem1.id
         returned_dist = results_with_dist[0][1]
         assert isinstance(returned_dist, float)
@@ -66,7 +66,7 @@ async def test_enhanced_store_add_search_list_stats(tmp_path: Path) -> None:
 
     store = EnhancedMemoryStore(settings)
     try:
-        results_after_reload = await store.semantic_search(vector=emb1, k=1)
+        results_after_reload = await store.semantic_search(embedding=emb1, k=1)
         assert results_after_reload and results_after_reload[0].id == mem1.id
     finally:
         await store.close()

--- a/tests/test_hypothesis_vectors.py
+++ b/tests/test_hypothesis_vectors.py
@@ -1,7 +1,7 @@
 """
-Property-based tests for EnhancedMemoryStore vector workflow.
+Property-based tests for EnhancedMemoryStore embedding workflow.
 
-The goal: whatever random float32 vector we add must be retrievable
+The goal: whatever random float32 embedding we add must be retrievable
 via an exact semantic search; the store must never raise or lose data.
 """
 
@@ -19,7 +19,7 @@ from memory_system.core.enhanced_store import EnhancedMemoryStore
 
 pytestmark = pytest.mark.property
 
-VECTOR_DIM = UnifiedSettings.for_testing().model.vector_dim
+EMBEDDING_DIM = UnifiedSettings.for_testing().model.vector_dim
 
 
 def _float32_arrays() -> SearchStrategy[List[float]]:
@@ -27,8 +27,8 @@ def _float32_arrays() -> SearchStrategy[List[float]]:
     return (
         st.lists(
             st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
-            min_size=VECTOR_DIM,
-            max_size=VECTOR_DIM,
+            min_size=EMBEDDING_DIM,
+            max_size=EMBEDDING_DIM,
         )
         .map(np.float32)
         .map(list)
@@ -45,9 +45,9 @@ async def store() -> AsyncGenerator[EnhancedMemoryStore, None]:
 
 @given(vec=_float32_arrays())
 @settings(max_examples=20, suppress_health_check=[HealthCheck.function_scoped_fixture])
-async def test_roundtrip_vector(store: EnhancedMemoryStore, vec: List[float]) -> None:
-    """Adding then searching the same vector must return exactly one hit."""
+async def test_roundtrip_embedding(store: EnhancedMemoryStore, vec: List[float]) -> None:
+    """Adding then searching the same embedding must return exactly one hit."""
     await store.add_memory(text="prop-test", embedding=vec)
-    hits = await store.semantic_search(vector=vec, k=1)
+    hits = await store.semantic_search(embedding=vec, k=1)
     assert len(hits) == 1
     assert hits[0].text == "prop-test"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -87,7 +87,7 @@ class TestEndToEndMemoryWorkflow:
 
         # Step 1: Generate embeddings
         texts = [mem["text"] for mem in memories]
-        embeddings = await embedding_service.encode(texts)
+        embeddings = await embedding_service.embed_text(texts)
 
         assert embeddings.shape[0] == len(memories)
         assert embeddings.shape[1] == 384
@@ -109,7 +109,7 @@ class TestEndToEndMemoryWorkflow:
 
         # Step 5: Search for similar memories
         query_text = "deep learning and neural networks"
-        query_embedding = await embedding_service.encode(query_text)
+        query_embedding = await embedding_service.embed_text(query_text)
 
         result_ids, distances = index.search(query_embedding.flatten(), k=3)
 
@@ -164,7 +164,7 @@ class TestEndToEndMemoryWorkflow:
             all_memories.extend(group_memories)
 
         texts = [mem["text"] for mem in all_memories]
-        embeddings = await embedding_service.encode(texts)
+        embeddings = await embedding_service.embed_text(texts)
 
         memory_ids = [mem["id"] for mem in all_memories]
 
@@ -182,7 +182,7 @@ class TestEndToEndMemoryWorkflow:
         }
 
         for domain, query in test_queries.items():
-            query_embedding = await embedding_service.encode(query)
+            query_embedding = await embedding_service.embed_text(query)
             result_ids, distances = index.search(query_embedding.flatten(), k=5)
 
             # Check that results are relevant to the domain
@@ -213,7 +213,7 @@ class TestEndToEndMemoryWorkflow:
         ]
 
         texts = [mem["text"] for mem in memories]
-        embeddings = await embedding_service.encode(texts)
+        embeddings = await embedding_service.embed_text(texts)
 
         # Store memories
         for i, memory in enumerate(memories):
@@ -239,7 +239,7 @@ class TestEndToEndMemoryWorkflow:
 
             # Test search on loaded index
             query_text = "persistence and durability"
-            query_embedding = await embedding_service.encode(query_text)
+            query_embedding = await embedding_service.embed_text(query_text)
 
             result_ids, distances = new_index.search(query_embedding.flatten(), k=2)
 
@@ -270,7 +270,7 @@ class TestEndToEndMemoryWorkflow:
 
             # Generate embeddings for batch
             texts = [mem["text"] for mem in batch_memories]
-            embeddings = await embedding_service.encode(texts)
+            embeddings = await embedding_service.embed_text(texts)
 
             # Add to storage (sequential within batch to avoid conflicts)
             for i, memory in enumerate(batch_memories):
@@ -310,7 +310,7 @@ class TestEndToEndMemoryWorkflow:
         # Test concurrent searches
         async def search_memories(query_text: str) -> Any:
             """Perform concurrent searches."""
-            query_embedding = await embedding_service.encode(query_text)
+            query_embedding = await embedding_service.embed_text(query_text)
             result_ids, distances = index.search(query_embedding.flatten(), k=3)
             return result_ids, distances
 

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -86,12 +86,12 @@ class TestEmbeddingPerformance:
         text = "This is a test sentence for performance evaluation."
 
         # Warm up
-        await embedding_service.encode(text)
+        await embedding_service.embed_text(text)
 
         # Measure performance
         start_time = time.perf_counter()
         for _ in range(10):
-            embedding = await embedding_service.encode(text)
+            embedding = await embedding_service.embed_text(text)
             assert embedding.shape[1] == 384
 
         end_time = time.perf_counter()
@@ -108,7 +108,7 @@ class TestEmbeddingPerformance:
 
         # Measure batch performance
         start_time = time.perf_counter()
-        embeddings = await embedding_service.encode(texts)
+        embeddings = await embedding_service.embed_text(texts)
         end_time = time.perf_counter()
 
         batch_time = end_time - start_time
@@ -125,13 +125,13 @@ class TestEmbeddingPerformance:
     async def test_concurrent_embedding_performance(self, embedding_service: EnhancedEmbeddingService) -> None:
         """Test performance under concurrent load."""
 
-        async def embed_text(text_id: int) -> np.ndarray:
+        async def embed(text_id: int) -> np.ndarray:
             text = f"Concurrent test text {text_id}"
-            return await embedding_service.encode(text)
+            return await embedding_service.embed_text(text)
 
         # Create concurrent tasks
         num_tasks = 20
-        tasks = [embed_text(i) for i in range(num_tasks)]
+        tasks = [embed(i) for i in range(num_tasks)]
 
         # Measure concurrent performance
         start_time = time.perf_counter()
@@ -155,14 +155,14 @@ class TestEmbeddingPerformance:
         text = "This text will be cached for performance testing."
 
         # Warm up to avoid initialization overhead and populate cache once
-        await embedding_service.encode(text)
+        await embedding_service.embed_text(text)
 
         async def measure(use_cache: bool, n: int = 5) -> float:
             times = []
             for i in range(n):
                 query = text if use_cache else f"{text} {i}"
                 start = time.perf_counter()
-                await embedding_service.encode(query)
+                await embedding_service.embed_text(query)
                 times.append(time.perf_counter() - start)
             return stats.median(times)
 
@@ -170,8 +170,8 @@ class TestEmbeddingPerformance:
         second_time = await measure(use_cache=True)
 
         # Results should be identical for cached queries
-        cached_embedding = await embedding_service.encode(text)
-        np.testing.assert_array_equal(cached_embedding, await embedding_service.encode(text))
+        cached_embedding = await embedding_service.embed_text(text)
+        np.testing.assert_array_equal(cached_embedding, await embedding_service.embed_text(text))
 
         # Cache hit should provide a noticeable speedup
         assert (
@@ -190,7 +190,7 @@ class TestEmbeddingPerformance:
         texts = [f"Memory test text {i}" for i in range(100)]
 
         for text in texts:
-            await embedding_service.encode(text)
+            await embedding_service.embed_text(text)
 
         final_memory = process.memory_info().rss
         memory_increase = (final_memory - initial_memory) / (1024 * 1024)  # MB

--- a/tests/test_precision_at_k.py
+++ b/tests/test_precision_at_k.py
@@ -1,6 +1,6 @@
 """
 Evaluates semantic_search precision@k with simple synthetic neighbours.
-Goal: at least 0.8 precision when querying near-identical vectors.
+Goal: at least 0.8 precision when querying near-identical embeddings.
 """
 
 import random
@@ -13,11 +13,11 @@ import pytest
 from memory_system.config.settings import UnifiedSettings
 from memory_system.core.enhanced_store import EnhancedMemoryStore
 
-DIM = UnifiedSettings.for_testing().model.vector_dim
+EMBEDDING_DIM = UnifiedSettings.for_testing().model.vector_dim
 
 
-def near(vec: List[float], eps: float = 0.0) -> List[float]:
-    return [float(x) + random.uniform(-eps, eps) for x in vec]
+def near(embedding: List[float], eps: float = 0.0) -> List[float]:
+    return [float(x) + random.uniform(-eps, eps) for x in embedding]
 
 
 @pytest.mark.asyncio
@@ -25,8 +25,8 @@ async def test_precision_at_k(tmp_path: Path) -> None:
     cfg = UnifiedSettings.for_testing()
     store = EnhancedMemoryStore(cfg)
 
-    # create 20 clusters of similar vectors
-    base = [np.random.rand(DIM).tolist() for _ in range(20)]
+    # create 20 clusters of similar embeddings
+    base = [np.random.rand(EMBEDDING_DIM).tolist() for _ in range(20)]
     for root in base:
         for _ in range(5):
             await store.add_memory(text="cluster", embedding=near(root))
@@ -35,7 +35,7 @@ async def test_precision_at_k(tmp_path: Path) -> None:
     hits, total = 0, 0
     for _ in range(100):
         q = near(random.choice(base))
-        res = await store.semantic_search(vector=q, k=5)
+        res = await store.semantic_search(embedding=q, k=5)
         total += 5
         hits += sum(r.text == "cluster" for r in res)
 

--- a/tests/test_semantic_search_benchmark.py
+++ b/tests/test_semantic_search_benchmark.py
@@ -23,12 +23,12 @@ from memory_system.config.settings import UnifiedSettings
 from memory_system.core.enhanced_store import EnhancedMemoryStore
 
 DIM = UnifiedSettings.for_testing().model.vector_dim
-RANDOM_VECTOR = np.random.rand(DIM).astype("float32").tolist()
+RANDOM_EMBEDDING = np.random.rand(DIM).astype("float32").tolist()
 
 
 @pytest_asyncio.fixture(scope="session")
 async def populated_store() -> AsyncGenerator[EnhancedMemoryStore, None]:
-    """Fill the index with 2 000 random vectors to make the test realistic."""
+    """Fill the index with 2 000 random embeddings to make the test realistic."""
     settings = UnifiedSettings.for_testing()
     store = EnhancedMemoryStore(settings)
     for _ in range(2_000):
@@ -50,7 +50,7 @@ def test_benchmark_semantic_search(benchmark: BenchmarkFixture, populated_store:
     benchmark(
         lambda: loop.run_until_complete(
             populated_store.semantic_search(
-                vector=RANDOM_VECTOR,
+                embedding=RANDOM_EMBEDDING,
                 k=5,
                 ef_search=ef,
             )


### PR DESCRIPTION
## Summary
- rename encode methods to embed_text in embedding service
- use "embedding" terminology for search parameters and cache
- update tests to use embed_text and embedding terms

## Testing
- `pytest tests/test_core.py::TestEnhancedEmbeddingService::test_embed_text_single_text -q` *(fails: No module named 'aiosqlite')*
- `pip install aiosqlite -q` *(fails: Could not find a version that satisfies the requirement aiosqlite)*

------
https://chatgpt.com/codex/tasks/task_e_689639a2ffe08325af4087059a009541