### PR TITLE
feat: add key management and libSQL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ pytest -q -m "not perf"
 
 | Env var                  | Default                | Description           |
 |--------------------------|------------------------|-----------------------|
-| AI_DATABASE__URL         | sqlite:///./data/memory.db | DB path / DSN     |
+| AI_DATABASE__URL         | sqlite:///./data/memory.db | DB path / DSN (use `libsql://` for remote) |
 | AI_SECURITY__ENCRYPT_AT_REST | false              | Enable SQLCipher      |
 | AI_MODEL__VECTOR_DIM     | 384                    | Embedding dimension   |
 | AI_PERF__MAX_WORKERS     | 4                      | Async workers         |
@@ -147,6 +147,20 @@ AI_DATABASE__URL=sqlite+sqlcipher:///./data/memory.db
 - **SQLCipher** – protects the entire database (metadata, indices). Choose when
   host or disk access is untrusted; requires the SQLCipher driver and adds a
   small performance cost.
+
+### Key management backends
+
+Encryption keys can be supplied directly or loaded from an external key
+management service. Configure this behaviour via the `kms_backend` field in
+`SecurityConfig`:
+
+```bash
+AI_SECURITY__KMS_BACKEND=local        # or 'vault', 'aws'
+AI_SECURITY__KMS_PARAMS='{"url":"https://vault"}'
+```
+
+`vault` and `aws` are currently placeholders that raise
+`NotImplementedError` when used.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@
    - FastAPI layer with auth, CORS, Prometheus metrics, rate limiting
    - Logs automatically scrub PII when enabled
    - Pluggable summarization strategies for memory consolidation
+   - Optional libSQL backend using `libsql-client`
 
 ### Summarization strategies
 
@@ -27,3 +28,18 @@ To enable SQLCipher for the SQLite backend, set `encrypt_at_rest` to `true`
 and supply a base64 Fernet key via the `encryption_key` setting or the
 `AI_SECURITY__ENCRYPTION_KEY` environment variable. The key is passed to the
 database as the `cipher_secret` parameter in the DSN.
+
+### Key management
+
+Keys can be loaded from different backends via the `kms_backend` option in
+`SecurityConfig`. Supported values are `local`, `vault` and `aws` (the latter
+two are placeholders). Additional connection details may be supplied through
+`kms_params`.
+
+```bash
+AI_SECURITY__KMS_BACKEND=local
+AI_SECURITY__KMS_PARAMS='{}'
+```
+
+When `kms_backend` is set to `local`, the `encryption_key` field is used
+directly. External backends are expected to return a Fernet compatible key.

--- a/memory_system/config/settings.py
+++ b/memory_system/config/settings.py
@@ -86,6 +86,8 @@ class SecurityConfig(BaseModel):
     max_text_length: PositiveInt = 10_000
     rate_limit_per_minute: PositiveInt = 1_000
     api_token: str = "your-secret-token-change-me"
+    kms_backend: str | None = None
+    kms_params: dict[str, Any] = Field(default_factory=dict)
 
     model_config = {"frozen": True}
 
@@ -119,6 +121,16 @@ class SecurityConfig(BaseModel):
     def _validate_token(cls, value: str) -> str:
         if len(value) < 8:
             raise ValueError("API token must be at least 8 characters long")
+        return value
+
+    @field_validator("kms_backend")
+    @classmethod
+    def _validate_kms_backend(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        allowed = {"local", "aws", "vault"}
+        if value not in allowed:
+            raise ValueError(f"kms_backend must be one of {allowed}")
         return value
 
 

--- a/memory_system/core/store.py
+++ b/memory_system/core/store.py
@@ -24,6 +24,60 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence,
 # ─────────────────────── third-party imports ───────────────────────
 import aiosqlite
 
+try:  # Optional libSQL support
+    from libsql_client import create_client as _create_libsql_client
+except Exception:  # pragma: no cover - libsql optional
+    _create_libsql_client = None
+
+
+class _LibSQLRow(dict):
+    """Row object that supports both index and key access."""
+
+    def __init__(self, columns: Sequence[str], values: Sequence[Any]) -> None:
+        super().__init__(zip(columns, values))
+        self._values = list(values)
+
+    def __getitem__(self, item: Any) -> Any:  # type: ignore[override]
+        if isinstance(item, int):
+            return self._values[item]
+        return super().__getitem__(item)
+
+
+class _LibSQLCursor:
+    def __init__(self, result: Any) -> None:
+        cols = getattr(result, "columns", [])
+        rows = getattr(result, "rows", [])
+        self._rows = [_LibSQLRow(cols, row) for row in rows]
+        self._iter = iter(self._rows)
+
+    async def fetchone(self) -> _LibSQLRow | None:
+        try:
+            return next(self._iter)
+        except StopIteration:
+            return None
+
+    async def fetchall(self) -> list[_LibSQLRow]:
+        return list(self._rows)
+
+
+class _LibSQLConnection:
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    async def execute(self, sql: str, params: Sequence[Any] | None = None) -> _LibSQLCursor:
+        res = await self._client.execute(sql, params or [])
+        return _LibSQLCursor(res)
+
+    async def executescript(self, script: str) -> None:
+        for stmt in filter(None, (s.strip() for s in script.split(";"))):
+            await self._client.execute(stmt)
+
+    async def commit(self) -> None:  # pragma: no cover - libsql auto commits
+        return None
+
+    async def close(self) -> None:
+        await self._client.close()
+
 if TYPE_CHECKING:  # pragma: no cover - optional FastAPI import for type hints
     from fastapi import FastAPI, Request
 
@@ -110,19 +164,26 @@ class SQLiteMemoryStore:
     """
 
     def __init__(self, dsn: str | Path = "file:memories.db?mode=rwc", *, pool_size: int = 5) -> None:
-        """Initialise the store with a SQLite DSN and connection pool size."""
+        """Initialise the store with a SQLite or libSQL DSN and pool size."""
+        self._use_libsql = False
         if isinstance(dsn, Path):
             self._path = dsn
             self._dsn = f"file:{dsn}?mode=rwc"
         else:
-            if dsn.startswith("sqlite+sqlcipher:///"):
+            if dsn.startswith("libsql://"):
+                self._dsn = dsn
+                self._use_libsql = True
+                self._path = Path(".")
+            elif dsn.startswith("sqlite+sqlcipher:///"):
                 path_part = dsn.split("sqlite+sqlcipher:///", 1)[1]
                 self._dsn = f"file:{path_part}?mode=rwc"
                 path_str = path_part
+                self._path = Path(path_str)
             elif dsn.startswith("sqlite:///"):
                 path_part = dsn.split("sqlite:///", 1)[1]
                 self._dsn = f"file:{path_part}?mode=rwc"
                 path_str = path_part
+                self._path = Path(path_str)
             else:
                 self._dsn = dsn
                 if dsn.startswith("file:"):
@@ -131,12 +192,13 @@ class SQLiteMemoryStore:
                     path_str = dsn.split("://", 1)[1].split("?", 1)[0]
                 else:
                     path_str = dsn
-            self._path = Path(path_str)
-        self._path.parent.mkdir(parents=True, exist_ok=True)
+                self._path = Path(path_str)
+        if not self._use_libsql:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
         self._pool_size = pool_size
-        self._pool: asyncio.LifoQueue[aiosqlite.Connection] = asyncio.LifoQueue(maxsize=pool_size)
+        self._pool: asyncio.LifoQueue[Any] = asyncio.LifoQueue(maxsize=pool_size)
         self._conn = object()  # placeholder for tests
-        self._acquired: set[aiosqlite.Connection] = set()
+        self._acquired: set[Any] = set()
         try:
             self._loop = asyncio.get_running_loop()
         except RuntimeError:  # no running loop
@@ -150,8 +212,19 @@ class SQLiteMemoryStore:
     # ---------------------------------------------------------------------
     # Low‑level connection helpers
     # ---------------------------------------------------------------------
-    async def _acquire(self) -> aiosqlite.Connection:
+    async def _acquire(self) -> Any:
         """Obtain a connection from the pool, creating one if necessary."""
+        if self._use_libsql:
+            try:
+                conn = self._pool.get_nowait()
+            except asyncio.QueueEmpty:
+                if _create_libsql_client is None:  # pragma: no cover - optional dep
+                    raise RuntimeError("libsql-client is not installed")
+                raw = await _create_libsql_client(self._dsn)
+                conn = _LibSQLConnection(raw)
+                self._created += 1
+            self._acquired.add(conn)
+            return conn
         try:
             conn = self._pool.get_nowait()
         except asyncio.QueueEmpty:
@@ -167,7 +240,7 @@ class SQLiteMemoryStore:
         self._acquired.add(conn)
         return conn
 
-    async def _release(self, conn: aiosqlite.Connection) -> None:
+    async def _release(self, conn: Any) -> None:
         """Return ``conn`` to the pool or close it if the pool is full."""
         self._acquired.discard(conn)
         try:

--- a/memory_system/utils/security.py
+++ b/memory_system/utils/security.py
@@ -40,7 +40,11 @@ from pydantic import BaseModel, SecretStr, ValidationInfo, field_validator
 
 __all__ = [
     "CryptoContext",
+    "KeyManager",
     "KeyManagementBackend",
+    "LocalKeyManager",
+    "VaultKeyManager",
+    "AWSKMSKeyManager",
     "LocalKeyBackend",
     "PIIPatterns",
     "EnhancedPIIFilter",
@@ -80,6 +84,48 @@ class ManagedKey(BaseModel):
 
     def as_fernet(self) -> Fernet:
         return Fernet(self.fernet_key.get_secret_value().encode())
+
+
+# ---------------------------------------------------------------------------
+# High level key manager interface
+# ---------------------------------------------------------------------------
+class KeyManager(ABC):
+    """Retrieve encryption keys from various backends."""
+
+    @abstractmethod
+    def get_key(self) -> str:
+        """Return a base64‑encoded 32‑byte key suitable for ``Fernet``."""
+        raise NotImplementedError
+
+
+class LocalKeyManager(KeyManager):
+    """Key manager that simply returns a provided local key."""
+
+    def __init__(self, key: str) -> None:
+        self._key = key
+
+    def get_key(self) -> str:
+        return self._key
+
+
+class VaultKeyManager(KeyManager):
+    """Placeholder for a HashiCorp Vault backed key manager."""
+
+    def __init__(self, **params: Any) -> None:
+        self.params = params
+
+    def get_key(self) -> str:  # pragma: no cover - placeholder
+        raise NotImplementedError("HashiCorp Vault integration not implemented")
+
+
+class AWSKMSKeyManager(KeyManager):
+    """Placeholder for an AWS KMS backed key manager."""
+
+    def __init__(self, **params: Any) -> None:
+        self.params = params
+
+    def get_key(self) -> str:  # pragma: no cover - placeholder
+        raise NotImplementedError("AWS KMS integration not implemented")
 
 
 # ---------------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,8 @@ torch>=2.2
 # Database
 psycopg2-binary>=2.9.7
 redis>=5.0
+libsql-client>=0.3.3
+aiosqlite>=0.19
 
 # Utilities
 python-dotenv>=1.0


### PR DESCRIPTION
## Summary
- add KeyManager interface with local and KMS placeholders
- expand SecurityConfig to choose KMS backends
- allow SQLiteMemoryStore to use libSQL via libsql-client
- document key management setup and libSQL configuration

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68967cd834bc8325aec06c75ba2e1d45