### PR TITLE
Optimize semantic search level filtering

### DIFF
--- a/memory_system/core/enhanced_store.py
+++ b/memory_system/core/enhanced_store.py
@@ -383,47 +383,32 @@ class EnhancedMemoryStore:
         list[Any]
             A list of memories (optionally paired with their distance).
         """
-        # Widen the ANN probe only if we plan to post-filter.
+        # Always filter by modality (and optional user metadata), retrieving
+        # matching rows in a single query so that we can avoid per-ID lookups.
         metadata_filter = dict(metadata_filter or {})
         metadata_filter.setdefault("modality", modality)
-        need_filter = True
         total = self._index.stats(modality).total_vectors or k
-        search_k = min((k * 5) if need_filter else k, max(1, total))
+        search_k = min(k * 5, max(1, total))
 
         vec = np.asarray(vector, dtype=np.float32)
 
         ids, dists = self._index.search(modality, vec, k=search_k, ef_search=ef_search)
         candidates = list(zip(ids, dists, strict=False))
 
-        if need_filter:
-            allowed_mems = await self._store.search(
-                metadata_filters=metadata_filter,
-                limit=total,  # cover whole corpus; store caps internally if needed
-            )
-            allowed_ids = {m.id for m in allowed_mems}
-            if level is not None:
-                # If Memory has a `level` field, filter by it as well
-                allowed_ids = {
-                    mid for mid in allowed_ids if (getattr(await self._store.get(mid), "level", None) == level)
-                }
-            if not allowed_ids:
-                return []
-            candidates = [(_id, dist) for _id, dist in candidates if _id in allowed_ids][:k]
-        else:
-            candidates = candidates[:k]
+        allowed_mems = await self._store.search(
+            metadata_filters=metadata_filter,
+            limit=total,  # cover whole corpus; store caps internally if needed
+            level=level,
+        )
+        allowed_map = {m.id: m for m in allowed_mems}
+        if not allowed_map:
+            return []
+        candidates = [(_id, dist) for _id, dist in candidates if _id in allowed_map][:k]
 
-        # Materialize Memory objects and build the final result list
-        results: list[Any] = []
-        for _id, dist in candidates:
-            mem = await self._store.get(_id)
-            if mem is None:
-                continue
-            if (level is not None) and (getattr(mem, "level", None) != level):
-                # Defensive guard in case the store call above didn’t filter by level
-                continue
-            results.append((mem, float(dist)) if return_distance else mem)
-
-        return results
+        # Materialize Memory objects from the cached mapping and build result
+        if return_distance:
+            return [(allowed_map[_id], float(dist)) for _id, dist in candidates]
+        return [allowed_map[_id] for _id, _ in candidates]
 
     async def list_memories(self, user_id: str | None = None) -> list[Memory]:
         """List memories, optionally filtering by ``user_id``."""

--- a/memory_system/core/store.py
+++ b/memory_system/core/store.py
@@ -330,7 +330,12 @@ class SQLiteMemoryStore:
                 if mem_count != fts_count:
                     await conn.execute("DELETE FROM memories_fts")
                     await conn.execute("INSERT INTO memories_fts(rowid, text) SELECT rowid, text FROM memories")
-                await conn.execute("CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories(created_at)")
+                await conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories(created_at)"
+                )
+                await conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_memories_level ON memories(level)"
+                )
                 await conn.commit()
                 self._initialised = True
             finally:

--- a/tests/test_enhanced_store.py
+++ b/tests/test_enhanced_store.py
@@ -18,6 +18,7 @@ import pytest_asyncio
 from memory_system.config.settings import UnifiedSettings
 from memory_system.core.enhanced_store import EnhancedMemoryStore
 from memory_system.core.index import ANNIndexError
+from memory_system.core.store import Memory
 
 
 @pytest_asyncio.fixture(scope="function")
@@ -88,6 +89,66 @@ async def test_invalid_embedding_length(store: EnhancedMemoryStore) -> None:
     bad_embedding = [0.1, 0.2, 0.3]
     with pytest.raises(ANNIndexError):
         await store.semantic_search(embedding=bad_embedding, k=1)
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_filters_by_level_and_is_faster(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = UnifiedSettings.for_testing()
+    store = EnhancedMemoryStore(settings)
+
+    dim = store.settings.model.vector_dim
+    emb0 = np.random.rand(dim).astype("float32").tolist()
+    emb1 = np.random.rand(dim).astype("float32").tolist()
+
+    # memory at level 0
+    mem0 = Memory.new("lvl0", level=0)
+    await store._store.add(mem0)
+    store._index.add_vectors("text", [mem0.id], np.asarray([emb0], dtype=np.float32))
+
+    # memory at level 1
+    mem1 = Memory.new("lvl1", level=1)
+    await store._store.add(mem1)
+    store._index.add_vectors("text", [mem1.id], np.asarray([emb1], dtype=np.float32))
+
+    # slow down individual get calls to highlight performance difference
+    orig_get = store._store.get
+
+    async def slow_get(mid: str) -> Memory | None:  # type: ignore[override]
+        await asyncio.sleep(0.01)
+        return await orig_get(mid)
+
+    monkeypatch.setattr(store._store, "get", slow_get)
+
+    async def naive_search(vec: list[float], level: int) -> list[Memory]:
+        vec_np = np.asarray(vec, dtype=np.float32)
+        ids, dists = store._index.search("text", vec_np, k=5)
+        candidates = list(zip(ids, dists))
+        total = store._index.stats("text").total_vectors or 5
+        allowed_mems = await store._store.search(metadata_filters={"modality": "text"}, limit=total)
+        allowed_ids = {m.id for m in allowed_mems}
+        allowed_ids = {
+            mid for mid in allowed_ids if getattr(await store._store.get(mid), "level", None) == level
+        }
+        candidates = [(_id, dist) for _id, dist in candidates if _id in allowed_ids][:1]
+        result = []
+        for _id, _ in candidates:
+            mem = await store._store.get(_id)
+            if mem:
+                result.append(mem)
+        return result
+
+    start = time.perf_counter()
+    old_res = await naive_search(emb0, level=0)
+    old_time = time.perf_counter() - start
+
+    start = time.perf_counter()
+    new_res = await store.semantic_search(vector=emb0, k=1, level=0)
+    new_time = time.perf_counter() - start
+
+    assert [m.id for m in new_res] == [m.id for m in old_res]
+    assert new_time < old_time
+
+    await store.close()
 
 
 # Optional extended check


### PR DESCRIPTION
## Summary
- add index on `level` column for faster level-based queries
- batch-fetch allowed memories and eliminate per-ID lookups in `semantic_search`
- add test ensuring semantic search filters by level and avoids extra DB calls

## Testing
- `pytest tests/test_enhanced_store.py::test_add_and_search tests/test_enhanced_store.py::test_semantic_search_filters_by_level_and_is_faster tests/test_hierarchical_summarizer.py::test_summarizer_no_higher_level -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*


------
https://chatgpt.com/codex/tasks/task_e_6896cabcc95c832583a369cce9a20847