### PR TITLE
Stream memory maintenance over chunks

### DIFF
--- a/memory_system/core/maintenance.py
+++ b/memory_system/core/maintenance.py
@@ -114,6 +114,7 @@ async def consolidate_store(
     threshold: float = 0.83,
     max_fetch: int = 100_000,
     strategy: str | SummaryStrategy = "head2tail",
+    chunk_size: int = 1_000,
 ) -> List[Memory]:
     """
     Cluster similar memories, create a summary memory per cluster, then delete
@@ -121,64 +122,55 @@ async def consolidate_store(
 
     Returns the list of created summary memories.
     """
-    # Fetch a large batch; the store does not have "fetch all" semantics.
-    all_mems = await store.search(limit=max_fetch)
-    if not all_mems:
-        return []
-
-    # Batch embeddings (faster than per-item).
-    texts = [m.text for m in all_mems]
-    embeddings = embed_text(texts)  # shape: (N, D)
-    if isinstance(embeddings, np.ndarray) and embeddings.ndim == 1:
-        embeddings = embeddings.reshape(1, -1)
-    assert embeddings.shape[0] == len(all_mems), "Embedding batch size mismatch"
-
-    clusters = cluster_memories([embeddings[i] for i in range(embeddings.shape[0])], threshold)
-
     created: List[Memory] = []
     ids_to_remove: List[str] = []
+    pending_adds: List[tuple[Memory, np.ndarray]] = []
 
-    for group in clusters:
-        # Ignore singletons (no consolidation needed).
-        if len(group) <= 1:
-            continue
+    async for chunk in store.search_iter(limit=max_fetch, chunk_size=chunk_size):
+        texts = [m.text for m in chunk]
+        embeddings = embed_text(texts)
+        if isinstance(embeddings, np.ndarray) and embeddings.ndim == 1:
+            embeddings = embeddings.reshape(1, -1)
+        clusters = cluster_memories([embeddings[i] for i in range(embeddings.shape[0])], threshold)
 
-        cluster_mems = [all_mems[i] for i in group]
-        summary_text, importance, valence, intensity = summarize_cluster(cluster_mems, strategy=strategy)
-        if not summary_text:
-            continue
+        for group in clusters:
+            if len(group) <= 1:
+                continue
 
-        summary_mem = Memory.new(
-            summary_text,
-            importance=importance,
-            valence=valence,
-            emotional_intensity=intensity,
-            metadata={
-                "type": "summary",
-                "source_ids": [m.id for m in cluster_mems],
-                "cluster_size": len(cluster_mems),
-            },
-        )
+            cluster_mems = [chunk[i] for i in group]
+            summary_text, importance, valence, intensity = summarize_cluster(cluster_mems, strategy=strategy)
+            if not summary_text:
+                continue
 
-        # Persist new memory & add embedding to ANN index.
-        await store.add(summary_mem)
-        summary_embedding = embed_text(summary_text)
-        if summary_embedding.ndim == 1:
-            summary_embedding = np.asarray([summary_embedding], dtype=np.float32)
-        index.add_vectors([summary_mem.id], summary_embedding.astype(np.float32, copy=False))
-        created.append(summary_mem)
+            summary_mem = Memory.new(
+                summary_text,
+                importance=importance,
+                valence=valence,
+                emotional_intensity=intensity,
+                metadata={
+                    "type": "summary",
+                    "source_ids": [m.id for m in cluster_mems],
+                    "cluster_size": len(cluster_mems),
+                },
+            )
 
-        # Schedule originals for removal.
-        ids_to_remove.extend(m.id for m in cluster_mems)
+            summary_embedding = embed_text(summary_text)
+            if summary_embedding.ndim == 1:
+                summary_embedding = np.asarray([summary_embedding], dtype=np.float32)
+            pending_adds.append((summary_mem, summary_embedding))
+            created.append(summary_mem)
+            ids_to_remove.extend(m.id for m in cluster_mems)
+
+    for mem, emb in pending_adds:
+        await store.add(mem)
+        index.add_vectors([mem.id], emb.astype(np.float32, copy=False))
 
     if ids_to_remove:
-        # Remove embeddings first, then rows.
         index.remove_ids(ids_to_remove)
         for mid in ids_to_remove:
             try:
                 await store.delete_memory(mid)
             except Exception:
-                # If a row is already gone, keep going.
                 pass
 
     return created
@@ -213,34 +205,36 @@ async def forget_old_memories(
     min_total: int = 1_000,
     retain_fraction: float = 0.85,
     max_fetch: int = 150_000,
+    chunk_size: int = 1_000,
 ) -> int:
     """
     Forget the lowest-scoring memories until we drop to the target size.
 
     Returns the number of deleted memories.
     """
-    all_mems = await store.search(limit=max_fetch)
-    total = len(all_mems)
+    now = _now_utc()
+
+    scored: list[tuple[float, str]] = []
+    total = 0
+    async for chunk in store.search_iter(limit=max_fetch, chunk_size=chunk_size):
+        for m in chunk:
+            total += 1
+            age_days = max(0.0, (now - m.created_at).total_seconds() / 86_400.0)
+            score = _decay_score(
+                importance=m.importance,
+                valence=m.valence,
+                emotional_intensity=m.emotional_intensity,
+                age_days=age_days,
+            )
+            scored.append((score, m.id))
+
     if total <= min_total:
         return 0
 
-    now = _now_utc()
-
-    # Compute scores.
-    scores: Dict[str, float] = {}
-    for m in all_mems:
-        age_days = max(0.0, (now - m.created_at).total_seconds() / 86_400.0)
-        scores[m.id] = _decay_score(
-            importance=m.importance,
-            valence=m.valence,
-            emotional_intensity=m.emotional_intensity,
-            age_days=age_days,
-        )
-
-    # Keep the top-K by score; forget the rest.
-    sorted_ids = sorted(scores, key=lambda k: scores[k], reverse=True)
     keep_count = max(min_total, int(total * retain_fraction))
-    ids_to_forget = sorted_ids[keep_count:]
+    scored.sort(key=lambda x: x[0], reverse=True)
+    keep_ids = {mid for _, mid in scored[:keep_count]}
+    ids_to_forget = [mid for _, mid in scored if mid not in keep_ids]
 
     if ids_to_forget:
         index.remove_ids(ids_to_forget)

--- a/memory_system/core/store.py
+++ b/memory_system/core/store.py
@@ -497,6 +497,7 @@ class SQLiteMemoryStore:
         metadata_filters: Optional[Dict[str, Any]] = None,
         limit: int = 20,
         level: int | None = None,
+        offset: int = 0,
     ) -> List[Memory]:
         """Full-text + JSON1 metadata search (no vectors here)."""
         await self.initialise()
@@ -522,7 +523,7 @@ class SQLiteMemoryStore:
                 if level is not None:
                     sql += " AND m.level = ?"
                     params.append(level)
-                sql += " ORDER BY bm25(memories_fts) LIMIT ?"
+                sql += " ORDER BY bm25(memories_fts) LIMIT ? OFFSET ?"
             else:
                 clauses: List[str] = []
                 if metadata_filters:
@@ -539,13 +540,46 @@ class SQLiteMemoryStore:
                 sql = "SELECT id, text, created_at, importance, valence, emotional_intensity, level, episode_id, modality, connections, metadata FROM memories"
                 if clauses:
                     sql += " WHERE " + " AND ".join(clauses)
-                sql += " ORDER BY created_at DESC LIMIT ?"
-            params.append(limit)
+                sql += " ORDER BY created_at DESC LIMIT ? OFFSET ?"
+            params.extend([limit, offset])
             cursor = await conn.execute(sql, params)
             rows = await cursor.fetchall()
             return [self._row_to_memory(r) for r in rows]
         finally:
             await self._release(conn)
+
+    async def search_iter(
+        self,
+        text_query: Optional[str] = None,
+        *,
+        metadata_filters: Optional[Dict[str, Any]] = None,
+        limit: int | None = None,
+        level: int | None = None,
+        chunk_size: int = 1000,
+    ) -> AsyncIterator[list[Memory]]:
+        """Yield search results in chunks to keep memory usage bounded."""
+
+        fetched = 0
+        offset = 0
+        while True:
+            batch_limit = chunk_size
+            if limit is not None:
+                remaining = limit - fetched
+                if remaining <= 0:
+                    break
+                batch_limit = min(batch_limit, remaining)
+            batch = await self.search(
+                text_query,
+                metadata_filters=metadata_filters,
+                limit=batch_limit,
+                level=level,
+                offset=offset,
+            )
+            if not batch:
+                break
+            yield batch
+            fetched += len(batch)
+            offset += len(batch)
 
     async def list_recent(self, *, n: int = 20, level: int | None = None) -> List[Memory]:
         """Return the most recent *n* memories, optionally filtered by level."""

--- a/tests/test_maintenance_memory.py
+++ b/tests/test_maintenance_memory.py
@@ -1,0 +1,60 @@
+import tracemalloc
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from memory_system.core.maintenance import consolidate_store, forget_old_memories
+from memory_system.core.store import Memory
+
+
+@pytest.mark.asyncio
+async def test_consolidate_store_memory_usage_bounded(store, index, fake_embed, monkeypatch):
+    big_text = "cat " + "x" * 9_996
+    for _ in range(1_000):
+        mem = Memory.new(big_text)
+        await store.add(mem)
+        vec = fake_embed(mem.text)
+        if isinstance(vec, np.ndarray) and vec.ndim == 1:
+            vec = vec.reshape(1, -1)
+        index.add_vectors([mem.id], vec.astype(np.float32))
+
+    import memory_system.core.maintenance as maint
+    monkeypatch.setattr(maint, "embed_text", fake_embed)
+
+    tracemalloc.start()
+    await consolidate_store(store, index, threshold=0.9, max_fetch=5_000, chunk_size=100)
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    assert peak < 12 * 1024 * 1024
+
+    remaining = await store.search(limit=5_000)
+    assert index.stats().total_vectors == len(remaining)
+
+
+@pytest.mark.asyncio
+async def test_forget_old_memories_memory_usage_bounded(store, index, fake_embed):
+    big_text = "cat " + "x" * 9_996
+    for i in range(1_000):
+        mem = Memory.new(big_text, importance=float(i % 100) / 100.0)
+        await store.add(mem)
+        vec = fake_embed(mem.text)
+        if isinstance(vec, np.ndarray) and vec.ndim == 1:
+            vec = vec.reshape(1, -1)
+        index.add_vectors([mem.id], vec.astype(np.float32))
+
+    tracemalloc.start()
+    deleted = await forget_old_memories(
+        store,
+        index,
+        min_total=500,
+        retain_fraction=0.5,
+        max_fetch=5_000,
+        chunk_size=100,
+    )
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    assert peak < 12 * 1024 * 1024
+
+    remaining = await store.search(limit=5_000)
+    assert index.stats().total_vectors == len(remaining)
+    assert deleted == 1_000 - len(remaining)


### PR DESCRIPTION
## Summary
- stream search results with new `search_iter` and optional offsets
- consolidate and forget memories using chunked iteration to bound memory
- add memory usage regression tests for maintenance utilities

## Testing
- `pytest tests/test_maintenance_memory.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896d08d8c6c8325818e9f247f412774