### PR TITLE
Add valence and intensity delta updates

### DIFF
--- a/aiosqlite/__init__.py
+++ b/aiosqlite/__init__.py
@@ -39,6 +39,18 @@ class Connection:
     async def close(self) -> None:
         await asyncio.to_thread(self._conn.close)
 
-async def connect(dsn: str, *, uri: bool = False) -> Connection:
-    conn = await asyncio.to_thread(sqlite3.connect, dsn, uri=uri)
+async def connect(
+    dsn: str, *, uri: bool = False, timeout: float | None = None
+) -> Connection:
+    """Lightweight async wrapper around :func:`sqlite3.connect`.
+
+    The real aiosqlite library exposes a ``timeout`` parameter – some parts of
+    the codebase rely on it.  Support it here for compatibility but fall back to
+    the default ``sqlite3`` behaviour if omitted.
+    """
+
+    if timeout is None:
+        conn = await asyncio.to_thread(sqlite3.connect, dsn, uri=uri)
+    else:
+        conn = await asyncio.to_thread(sqlite3.connect, dsn, uri=uri, timeout=timeout)
     return Connection(conn)

--- a/memory_system/api/schemas.py
+++ b/memory_system/api/schemas.py
@@ -69,6 +69,8 @@ class MemoryUpdate(BaseModel):
     tags: list[str] | None = Field(default=None, max_length=10)
     valence: float | None = Field(default=None, ge=-1.0, le=1.0)
     emotional_intensity: float | None = Field(default=None, ge=0.0, le=1.0)
+    valence_delta: float | None = Field(default=None)
+    emotional_intensity_delta: float | None = Field(default=None)
 
     model_config = {
         "extra": "forbid",

--- a/memory_system/core/store.py
+++ b/memory_system/core/store.py
@@ -655,13 +655,18 @@ class SQLiteMemoryStore:
         metadata: Dict[str, Any] | None = None,
         importance: float | None = None,
         importance_delta: float | None = None,
+        valence: float | None = None,
+        valence_delta: float | None = None,
+        emotional_intensity: float | None = None,
+        emotional_intensity_delta: float | None = None,
     ) -> Memory:
-        """Update text, importance and/or metadata of an existing memory.
+        """Update text, importance, valence, intensity and metadata of a memory.
 
-        If ``importance_delta`` is provided, the ``importance`` column is
-        incremented by that amount.  A concrete ``importance`` value overrides
-        the existing one.  Metadata is **merged** with existing JSON rather than
-        replacing it outright.
+        ``*_delta`` parameters increment existing values and are clamped to the
+        valid range (``importance``/``emotional_intensity`` → ``0..1``,
+        ``valence`` → ``-1..1``).  Concrete values take precedence over deltas.
+        Metadata is **merged** with existing JSON rather than replacing it
+        outright.
         """
 
         await self.initialise()
@@ -684,6 +689,32 @@ class SQLiteMemoryStore:
                     "SET importance = MAX(0.0, MIN(1.0, importance + ?)) "
                     "WHERE id = ?",
                     (importance_delta, memory_id),
+                )
+
+            if valence is not None:
+                await conn.execute(
+                    "UPDATE memories SET valence = ? WHERE id = ?",
+                    (valence, memory_id),
+                )
+            elif valence_delta is not None:
+                await conn.execute(
+                    "UPDATE memories "
+                    "SET valence = MAX(-1.0, MIN(1.0, valence + ?)) "
+                    "WHERE id = ?",
+                    (valence_delta, memory_id),
+                )
+
+            if emotional_intensity is not None:
+                await conn.execute(
+                    "UPDATE memories SET emotional_intensity = ? WHERE id = ?",
+                    (emotional_intensity, memory_id),
+                )
+            elif emotional_intensity_delta is not None:
+                await conn.execute(
+                    "UPDATE memories "
+                    "SET emotional_intensity = MAX(0.0, MIN(1.0, emotional_intensity + ?)) "
+                    "WHERE id = ?",
+                    (emotional_intensity_delta, memory_id),
                 )
 
             if metadata is not None and metadata:

--- a/memory_system/unified_memory.py
+++ b/memory_system/unified_memory.py
@@ -67,6 +67,12 @@ class MemoryStoreProtocol(Protocol):
         *,
         text: str | None = None,
         metadata: MutableMapping[str, Any] | None = None,
+        importance: float | None = None,
+        importance_delta: float | None = None,
+        valence: float | None = None,
+        valence_delta: float | None = None,
+        emotional_intensity: float | None = None,
+        emotional_intensity_delta: float | None = None,
     ) -> Memory: ...
 
     async def list_recent(self, *, n: int = 20) -> Sequence[Memory]: ...
@@ -234,6 +240,8 @@ async def update(
     *,
     text: str | None = None,
     metadata: MutableMapping[str, Any] | None = None,
+    valence_delta: float | None = None,
+    emotional_intensity_delta: float | None = None,
     store: MemoryStoreProtocol | None = None,
 ) -> Memory:
     """Update text and/or metadata of an existing memory and return the new object.
@@ -242,6 +250,10 @@ async def update(
         memory_id (str): The memory identifier.
         text (str | None, optional): New text. Defaults to None.
         metadata (MutableMapping[str, Any] | None, optional): New metadata. Defaults to None.
+        valence_delta (float | None, optional): Increment for emotional valence.
+            Defaults to None.
+        emotional_intensity_delta (float | None, optional): Increment for
+            emotional intensity. Defaults to None.
         store (MemoryStoreProtocol | None, optional): Store object. Defaults to None.
 
     Returns:
@@ -250,7 +262,14 @@ async def update(
     st = await _resolve_store(store)
     try:
         updated = await asyncio.wait_for(
-            st.update_memory(memory_id, text=text, metadata=metadata), timeout=ASYNC_TIMEOUT
+            st.update_memory(
+                memory_id,
+                text=text,
+                metadata=metadata,
+                valence_delta=valence_delta,
+                emotional_intensity_delta=emotional_intensity_delta,
+            ),
+            timeout=ASYNC_TIMEOUT,
         )
         logger.debug("Memory %s updated.", memory_id)
     except Exception as e:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -267,12 +267,20 @@ class TestSchemas:
         assert update.text is None
         assert update.role is None
         assert update.tags is None
+        assert update.valence_delta is None
+        assert update.emotional_intensity_delta is None
 
         # Partial update
-        update = MemoryUpdate(text="Updated text")
+        update = MemoryUpdate(
+            text="Updated text",
+            valence_delta=0.2,
+            emotional_intensity_delta=-0.1,
+        )
         assert update.text == "Updated text"
         assert update.role is None
         assert update.tags is None
+        assert abs(update.valence_delta - 0.2) < 1e-9
+        assert abs(update.emotional_intensity_delta + 0.1) < 1e-9
 
     def test_memory_query_schema(self) -> None:
         """Test MemoryQuery schema."""

--- a/tests/test_store_ext.py
+++ b/tests/test_store_ext.py
@@ -8,7 +8,7 @@ import pytest
 
 from memory_system.core.store import Memory, SQLiteMemoryStore, get_store
 from memory_system.unified_memory import add as um_add
-from memory_system.unified_memory import reinforce
+from memory_system.unified_memory import reinforce, update as um_update
 
 
 @pytest.fixture
@@ -211,5 +211,56 @@ def test_reinforce_returns_updated_importance(store: SQLiteMemoryStore) -> None:
         updated = await reinforce(mem.memory_id, 0.2, store=store)
 
         assert abs(updated.importance - 0.3) < 1e-6
+
+    asyncio.run(_run())
+
+
+def test_update_memory_valence_delta_clamps(store: SQLiteMemoryStore) -> None:
+    async def _run() -> None:
+        mem = Memory.new("base", valence=0.0)
+        await store.add(mem)
+
+        updated = await store.update_memory(mem.id, valence_delta=0.5)
+        assert abs(updated.valence - 0.5) < 1e-6
+
+        updated = await store.update_memory(mem.id, valence_delta=1.0)
+        assert abs(updated.valence - 1.0) < 1e-6
+
+        updated = await store.update_memory(mem.id, valence_delta=-3.0)
+        assert abs(updated.valence - (-1.0)) < 1e-6
+
+    asyncio.run(_run())
+
+
+def test_update_memory_emotional_intensity_delta_clamps(
+    store: SQLiteMemoryStore,
+) -> None:
+    async def _run() -> None:
+        mem = Memory.new("base", emotional_intensity=0.4)
+        await store.add(mem)
+
+        updated = await store.update_memory(mem.id, emotional_intensity_delta=0.3)
+        assert abs(updated.emotional_intensity - 0.7) < 1e-6
+
+        updated = await store.update_memory(mem.id, emotional_intensity_delta=1.0)
+        assert abs(updated.emotional_intensity - 1.0) < 1e-6
+
+        updated = await store.update_memory(mem.id, emotional_intensity_delta=-2.0)
+        assert abs(updated.emotional_intensity - 0.0) < 1e-6
+
+    asyncio.run(_run())
+
+
+def test_unified_update_applies_deltas(store: SQLiteMemoryStore) -> None:
+    async def _run() -> None:
+        mem = await um_add("hi", store=store)
+        updated = await um_update(
+            mem.memory_id,
+            valence_delta=0.6,
+            emotional_intensity_delta=0.4,
+            store=store,
+        )
+        assert abs(updated.valence - 0.6) < 1e-6
+        assert abs(updated.emotional_intensity - 0.4) < 1e-6
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- Allow SQLite memory updates to adjust valence and emotional intensity with clamping
- Expose valence_delta and emotional_intensity_delta through unified API and schema
- Test delta updates and ensure in-memory aiosqlite stub handles timeout

## Testing
- `pytest tests/test_store_ext.py::test_update_memory_valence_delta_clamps tests/test_store_ext.py::test_update_memory_emotional_intensity_delta_clamps tests/test_store_ext.py::test_unified_update_applies_deltas -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install httpx fastapi pytest-asyncio -q` *(fails: Could not find a version that satisfies the requirement httpx)*

------
https://chatgpt.com/codex/tasks/task_e_6896d3093204832589f35203ca66e84a