### PR TITLE
Add valence and intensity reinforcement deltas

### DIFF
--- a/aiosqlite/__init__.py
+++ b/aiosqlite/__init__.py
@@ -39,6 +39,6 @@ class Connection:
     async def close(self) -> None:
         await asyncio.to_thread(self._conn.close)
 
-async def connect(dsn: str, *, uri: bool = False) -> Connection:
-    conn = await asyncio.to_thread(sqlite3.connect, dsn, uri=uri)
+async def connect(dsn: str, *, uri: bool = False, timeout: float | None = None) -> Connection:
+    conn = await asyncio.to_thread(sqlite3.connect, dsn, uri=uri, timeout=timeout or 5)
     return Connection(conn)

--- a/memory_system/core/store.py
+++ b/memory_system/core/store.py
@@ -655,13 +655,18 @@ class SQLiteMemoryStore:
         metadata: Dict[str, Any] | None = None,
         importance: float | None = None,
         importance_delta: float | None = None,
+        valence: float | None = None,
+        valence_delta: float | None = None,
+        emotional_intensity: float | None = None,
+        emotional_intensity_delta: float | None = None,
     ) -> Memory:
-        """Update text, importance and/or metadata of an existing memory.
+        """Update text, emotional attributes and/or metadata of a memory.
 
-        If ``importance_delta`` is provided, the ``importance`` column is
-        incremented by that amount.  A concrete ``importance`` value overrides
-        the existing one.  Metadata is **merged** with existing JSON rather than
-        replacing it outright.
+        If ``*_delta`` values are provided the respective columns are adjusted
+        by that amount (clamped to their valid ranges).  Explicit ``importance``,
+        ``valence`` or ``emotional_intensity`` values override existing ones.
+        Metadata is **merged** with existing JSON rather than replacing it
+        outright.
         """
 
         await self.initialise()
@@ -684,6 +689,32 @@ class SQLiteMemoryStore:
                     "SET importance = MAX(0.0, MIN(1.0, importance + ?)) "
                     "WHERE id = ?",
                     (importance_delta, memory_id),
+                )
+
+            if valence is not None:
+                await conn.execute(
+                    "UPDATE memories SET valence = ? WHERE id = ?",
+                    (valence, memory_id),
+                )
+            elif valence_delta is not None:
+                await conn.execute(
+                    "UPDATE memories "
+                    "SET valence = MAX(-1.0, MIN(1.0, valence + ?)) "
+                    "WHERE id = ?",
+                    (valence_delta, memory_id),
+                )
+
+            if emotional_intensity is not None:
+                await conn.execute(
+                    "UPDATE memories SET emotional_intensity = ? WHERE id = ?",
+                    (emotional_intensity, memory_id),
+                )
+            elif emotional_intensity_delta is not None:
+                await conn.execute(
+                    "UPDATE memories "
+                    "SET emotional_intensity = MAX(0.0, MIN(1.0, emotional_intensity + ?)) "
+                    "WHERE id = ?",
+                    (emotional_intensity_delta, memory_id),
                 )
 
             if metadata is not None and metadata:

--- a/memory_system/unified_memory.py
+++ b/memory_system/unified_memory.py
@@ -67,6 +67,12 @@ class MemoryStoreProtocol(Protocol):
         *,
         text: str | None = None,
         metadata: MutableMapping[str, Any] | None = None,
+        importance: float | None = None,
+        importance_delta: float | None = None,
+        valence: float | None = None,
+        valence_delta: float | None = None,
+        emotional_intensity: float | None = None,
+        emotional_intensity_delta: float | None = None,
     ) -> Memory: ...
 
     async def list_recent(self, *, n: int = 20) -> Sequence[Memory]: ...
@@ -263,13 +269,22 @@ async def reinforce(
     memory_id: str,
     amount: float = 0.1,
     *,
+    valence_delta: float | None = None,
+    intensity_delta: float | None = None,
     store: MemoryStoreProtocol | None = None,
 ) -> Memory:
-    """Reinforce the importance of a memory by *amount* and return the updated object.
+    """Reinforce a memory's importance and optionally its emotional context.
+
+    By default only the ``importance`` field is reinforced. Supplying
+    ``valence_delta`` and/or ``intensity_delta`` applies the same deltas to
+    the respective ``valence`` and ``emotional_intensity`` attributes.
 
     Args:
         memory_id (str): The memory identifier.
-        amount (float, optional): Amount to reinforce. Defaults to 0.1.
+        amount (float, optional): Importance increment. Defaults to 0.1.
+        valence_delta (float | None, optional): Change applied to ``valence``.
+        intensity_delta (float | None, optional): Change applied to
+            ``emotional_intensity``.
         store (MemoryStoreProtocol | None, optional): Store object. Defaults to None.
 
     Returns:
@@ -281,7 +296,13 @@ async def reinforce(
     }
     try:
         updated = await asyncio.wait_for(
-            st.update_memory(memory_id, importance_delta=amount, metadata=meta),
+            st.update_memory(
+                memory_id,
+                importance_delta=amount,
+                valence_delta=valence_delta,
+                emotional_intensity_delta=intensity_delta,
+                metadata=meta,
+            ),
             timeout=ASYNC_TIMEOUT,
         )
         logger.debug("Memory %s reinforced by %.2f.", memory_id, amount)

--- a/tests/test_store_ext.py
+++ b/tests/test_store_ext.py
@@ -207,9 +207,35 @@ def test_update_memory_clamps_importance_lower_bound(store: SQLiteMemoryStore) -
 
 def test_reinforce_returns_updated_importance(store: SQLiteMemoryStore) -> None:
     async def _run() -> None:
-        mem = await um_add("hi", importance=0.1, store=store)
+        mem = await um_add("hi", importance=0.1, valence=0.2, emotional_intensity=0.4, store=store)
         updated = await reinforce(mem.memory_id, 0.2, store=store)
 
         assert abs(updated.importance - 0.3) < 1e-6
+        assert updated.valence == pytest.approx(0.2)
+        assert updated.emotional_intensity == pytest.approx(0.4)
+
+    asyncio.run(_run())
+
+
+def test_reinforce_combined_fields(store: SQLiteMemoryStore) -> None:
+    async def _run() -> None:
+        mem = await um_add(
+            "hi",
+            importance=0.1,
+            valence=0.0,
+            emotional_intensity=0.2,
+            store=store,
+        )
+        updated = await reinforce(
+            mem.memory_id,
+            0.2,
+            valence_delta=0.3,
+            intensity_delta=0.4,
+            store=store,
+        )
+
+        assert updated.importance == pytest.approx(0.3)
+        assert updated.valence == pytest.approx(0.3)
+        assert updated.emotional_intensity == pytest.approx(0.6)
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- allow reinforcement to adjust valence and emotional intensity in addition to importance
- support valence and intensity deltas in SQLite store update
- cover combined reinforcement with new tests

## Testing
- `pytest tests/test_store_ext.py::test_reinforce_returns_updated_importance -q`
- `pytest tests/test_store_ext.py::test_reinforce_combined_fields -q`
- `pytest tests/test_store_ext.py -q` *(fails: async def functions are not natively supported)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install httpx numpy fastapi cryptography prometheus_client pytest_asyncio -q` *(fails: Cannot connect to proxy)*
- `pip install pre-commit -q` *(fails: Could not find a version that satisfies the requirement httpx)*
- `pre-commit run --files memory_system/unified_memory.py memory_system/core/store.py tests/test_store_ext.py aiosqlite/__init__.py` *(command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_6896d309ea288325831fa820ddbf2e0d