### PR TITLE
feat: add configurable ranking weights

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,23 @@ Clusters can be condensed using different approaches:
 Callers may also provide custom callables implementing their own summarization
 logic when invoking the maintenance APIs.
 
+### Ranking best memories
+
+The `/api/v1/memory/best` endpoint scores memories using weighted attributes:
+
+- `importance`
+- `emotional_intensity`
+- `valence_pos` *(positive valence weight)*
+- `valence_neg` *(negative valence penalty)*
+
+Defaults are configured via `RankingConfig` and may be overridden with
+environment variables such as `AI_RANKING__IMPORTANCE=2.0`.
+Per-request weights can be supplied as query parameters:
+
+```bash
+curl "http://localhost:8000/api/v1/memory/best?limit=2&importance=2.0&valence_neg=1.0"
+```
+
 ## Database Encryption
 
 To enable SQLCipher for the SQLite backend, set `encrypt_at_rest` to `true`

--- a/memory_system/api/routes/memory.py
+++ b/memory_system/api/routes/memory.py
@@ -84,9 +84,24 @@ async def search_memories(
 
 
 @router.get("/best", response_model=list[MemoryRead])
-async def best_memories(request: Request, limit: int = Query(5, ge=1, le=50)) -> list[MemoryRead]:
+async def best_memories(
+    request: Request,
+    limit: int = Query(5, ge=1, le=50),
+    importance: float | None = Query(None, ge=0.0),
+    emotional_intensity: float | None = Query(None, ge=0.0),
+    valence_pos: float | None = Query(None, ge=0.0),
+    valence_neg: float | None = Query(None, ge=0.0),
+) -> list[MemoryRead]:
     """Return the most important memories ranked by score."""
     store = await _store(request)
-    records = await unified_memory.list_best(n=limit, store=store)
+    weights = None
+    if any(v is not None for v in (importance, emotional_intensity, valence_pos, valence_neg)):
+        weights = unified_memory.ListBestWeights(
+            importance=importance or 1.0,
+            emotional_intensity=emotional_intensity or 1.0,
+            valence_pos=valence_pos or 1.0,
+            valence_neg=valence_neg or 0.5,
+        )
+    records = await unified_memory.list_best(n=limit, store=store, weights=weights)
     payload = [MemoryRead.model_validate(asdict(r)) for r in records]
     return payload

--- a/memory_system/config/settings.py
+++ b/memory_system/config/settings.py
@@ -29,6 +29,7 @@ __all__ = [
     "SecurityConfig",
     "PerformanceConfig",
     "ReliabilityConfig",
+    "RankingConfig",
     "APIConfig",
     "MonitoringConfig",
     "UnifiedSettings",
@@ -188,6 +189,17 @@ class ReliabilityConfig(BaseModel):
     model_config = {"frozen": True}
 
 
+class RankingConfig(BaseModel):
+    """Weighting for ranking memories via :func:`list_best`."""
+
+    importance: float = 1.0
+    emotional_intensity: float = 1.0
+    valence_pos: float = 1.0
+    valence_neg: float = 0.5
+
+    model_config = {"frozen": True}
+
+
 class APIConfig(BaseModel):
     """HTTP API options."""
 
@@ -252,6 +264,7 @@ class UnifiedSettings(BaseSettings):
     security: SecurityConfig = SecurityConfig()
     performance: PerformanceConfig = PerformanceConfig()
     reliability: ReliabilityConfig = ReliabilityConfig()
+    ranking: RankingConfig = RankingConfig()
     api: APIConfig = APIConfig()
     monitoring: MonitoringConfig = MonitoringConfig()
 
@@ -270,6 +283,7 @@ class UnifiedSettings(BaseSettings):
             PerformanceConfig(**self.performance.model_dump()),
         )
         object.__setattr__(self, "reliability", ReliabilityConfig(**self.reliability.model_dump()))
+        object.__setattr__(self, "ranking", RankingConfig(**self.ranking.model_dump()))
         object.__setattr__(self, "api", APIConfig(**self.api.model_dump()))
         object.__setattr__(self, "monitoring", MonitoringConfig(**self.monitoring.model_dump()))
 
@@ -408,6 +422,7 @@ class UnifiedSettings(BaseSettings):
             "security": scrub(self.security),
             "performance": scrub(self.performance),
             "reliability": scrub(self.reliability),
+            "ranking": scrub(self.ranking),
             "api": scrub(self.api),
             "monitoring": scrub(self.monitoring),
         }

--- a/memory_system/unified_memory.py
+++ b/memory_system/unified_memory.py
@@ -422,7 +422,13 @@ async def list_best(
     """
     st = await _resolve_store(store)
     if weights is None:
-        weights = ListBestWeights()
+        try:  # load from configuration if available
+            from memory_system.config.settings import get_settings
+
+            cfg = get_settings()
+            weights = ListBestWeights(**cfg.ranking.model_dump())
+        except Exception:  # pragma: no cover - settings module optional
+            weights = ListBestWeights()
     try:
         if include_all:
             # Attempt to leverage store-level optimisation for full scans

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import time
+from pathlib import Path
 from typing import AsyncGenerator
 
 import httpx
@@ -479,6 +480,41 @@ class TestMemoryEndpoints:
         resp = test_client.get("/api/v1/memory/best", params={"limit": 2})
         assert resp.status_code == 200
         assert len(resp.json()) == 2
+
+    def test_best_memories_custom_weights(self, test_client: TestClient, tmp_path: Path) -> None:
+        """Custom weights passed via query parameters should influence ranking."""
+        import asyncio
+        from memory_system.core.store import get_store
+
+        loop = asyncio.get_event_loop()
+        store = loop.run_until_complete(get_store(tmp_path / "api.db"))
+        loop.run_until_complete(
+            unified_memory.add(
+                "good",
+                valence=0.5,
+                emotional_intensity=1.0,
+                importance=1.0,
+                store=store,
+            )
+        )
+        loop.run_until_complete(
+            unified_memory.add(
+                "bad but vital",
+                valence=-0.5,
+                emotional_intensity=1.0,
+                importance=1.4,
+                store=store,
+            )
+        )
+
+        resp_default = test_client.get("/api/v1/memory/best", params={"limit": 2})
+        assert resp_default.json()[0]["text"] == "good"
+
+        resp_weighted = test_client.get(
+            "/api/v1/memory/best",
+            params={"limit": 2, "importance": 2.0},
+        )
+        assert resp_weighted.json()[0]["text"] == "bad but vital"
 
 
 class TestErrorHandling:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -415,6 +415,7 @@ class TestUnifiedSettings:
         assert "performance" in summary
         assert "api" in summary
         assert "monitoring" in summary
+        assert "ranking" in summary
 
         # Check that sensitive data is not included
         assert "api_token" not in str(summary)

--- a/tests/test_list_best.py
+++ b/tests/test_list_best.py
@@ -60,3 +60,25 @@ async def test_include_all_scans_beyond_recent(store):
 
     full_scan = await um.list_best(n=1, store=store, include_all=True)
     assert full_scan[0].memory_id == old.memory_id
+
+
+@pytest.mark.asyncio
+async def test_config_weights_change_ranking(monkeypatch, store):
+    """Weights from configuration should affect ranking when not passed explicitly."""
+    from memory_system.config.settings import RankingConfig, UnifiedSettings
+
+    settings = UnifiedSettings.for_testing()
+    settings.ranking = RankingConfig(importance=2.0)
+    monkeypatch.setattr("memory_system.config.settings.get_settings", lambda env=None: settings)
+
+    pos = await um.add("good", valence=0.5, emotional_intensity=1.0, importance=1.0, store=store)
+    neg = await um.add(
+        "bad but vital",
+        valence=-0.5,
+        emotional_intensity=1.0,
+        importance=1.4,
+        store=store,
+    )
+
+    best = await um.list_best(n=2, store=store)
+    assert best[0].memory_id == neg.memory_id


### PR DESCRIPTION
## Summary
- allow `list_best` to pull ranking weights from settings
- accept ranking weights via `/memory/best` query params
- document weight format with configuration and API example

## Testing
- `pytest tests/test_list_best.py::test_config_weights_change_ranking -q` *(fails: async def functions are not natively supported)*
- `pytest tests/test_api.py -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pytest tests/test_config.py -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_6896e5e6fc1c83259fea59398f2db3c0