### PR TITLE
Track last access and TTL-based expiration for memories

### DIFF
--- a/memory_system/core/maintenance.py
+++ b/memory_system/core/maintenance.py
@@ -207,18 +207,40 @@ async def forget_old_memories(
     retain_fraction: float = 0.85,
     max_fetch: int = 150_000,
     chunk_size: int = 1_000,
+    ttl: float | None = None,
 ) -> int:
     """
     Forget the lowest-scoring memories until we drop to the target size.
+
+    Memories with a ``last_accessed`` timestamp older than ``ttl`` seconds are
+    always expired: their importance is lowered and they are removed regardless
+    of ``retain_fraction``.
 
     Returns the number of deleted memories.
     """
     now = _now_utc()
 
     scored: list[tuple[float, str]] = []
+    expired: list[str] = []
     total = 0
     async for chunk in store.search_iter(limit=max_fetch, chunk_size=chunk_size):
         for m in chunk:
+            last_access = m.created_at
+            if ttl is not None and m.metadata:
+                ts = m.metadata.get("last_accessed")
+                if isinstance(ts, str):
+                    try:
+                        last_access = dt.datetime.fromisoformat(ts)
+                    except ValueError:
+                        last_access = m.created_at
+            if ttl is not None and (now - last_access).total_seconds() > ttl:
+                try:
+                    await store.update_memory(m.id, importance=0.0)
+                except Exception:
+                    pass
+                expired.append(m.id)
+                continue
+
             total += 1
             age_days = max(0.0, (now - m.created_at).total_seconds() / 86_400.0)
             score = _decay_score(
@@ -229,8 +251,16 @@ async def forget_old_memories(
             )
             scored.append((score, m.id))
 
+    if expired:
+        index.remove_ids(expired)
+        for mid in expired:
+            try:
+                await store.delete_memory(mid)
+            except Exception:
+                pass
+
     if total <= min_total:
-        return 0
+        return len(expired)
 
     keep_count = max(min_total, int(total * retain_fraction))
     scored.sort(key=lambda x: x[0], reverse=True)
@@ -245,7 +275,7 @@ async def forget_old_memories(
             except Exception:
                 pass
 
-    return len(ids_to_forget)
+    return len(ids_to_forget) + len(expired)
 
 
 async def periodic_hierarchy_update(

--- a/memory_system/unified_memory.py
+++ b/memory_system/unified_memory.py
@@ -250,6 +250,9 @@ async def update(
 ) -> Memory:
     """Update text and/or metadata of an existing memory and return the new object.
 
+    ``last_accessed`` in the memory's metadata is automatically set to the
+    current UTC timestamp.
+
     Args:
         memory_id (str): The memory identifier.
         text (str | None, optional): New text. Defaults to None.
@@ -264,12 +267,14 @@ async def update(
         Memory: The updated memory object.
     """
     st = await _resolve_store(store)
+    meta: MutableMapping[str, Any] = dict(copy.deepcopy(metadata) if metadata else {})
+    meta["last_accessed"] = _dt.datetime.utcnow().replace(tzinfo=_dt.timezone.utc).isoformat()
     try:
         updated = await asyncio.wait_for(
             st.update_memory(
                 memory_id,
                 text=text,
-                metadata=metadata,
+                metadata=meta,
                 valence_delta=valence_delta,
                 emotional_intensity_delta=emotional_intensity_delta,
             ),
@@ -292,6 +297,8 @@ async def reinforce(
 ) -> Memory:
     """Reinforce a memory's importance and optionally its emotional context.
 
+    The memory's metadata receives an updated ``last_accessed`` timestamp.
+
     By default only the ``importance`` field is reinforced. Supplying
     ``valence_delta`` and/or ``intensity_delta`` applies the same deltas to
     the respective ``valence`` and ``emotional_intensity`` attributes.
@@ -308,6 +315,7 @@ async def reinforce(
         Memory: The reinforced memory object.
     """
     st = await _resolve_store(store)
+    meta = {"last_accessed": _dt.datetime.utcnow().replace(tzinfo=_dt.timezone.utc).isoformat()}
     try:
         updated = await asyncio.wait_for(
             st.update_memory(
@@ -315,6 +323,7 @@ async def reinforce(
                 importance_delta=amount,
                 valence_delta=valence_delta,
                 emotional_intensity_delta=intensity_delta,
+                metadata=meta,
             ),
             timeout=ASYNC_TIMEOUT,
         )

--- a/tests/test_forget_ttl.py
+++ b/tests/test_forget_ttl.py
@@ -1,0 +1,64 @@
+import asyncio
+import datetime as dt
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from memory_system.core.maintenance import forget_old_memories
+from memory_system.core.store import Memory, SQLiteMemoryStore
+
+try:  # pragma: no cover - optional dependency
+    from memory_system.core.index import FaissHNSWIndex
+except Exception:  # pragma: no cover - optional dependency
+    FaissHNSWIndex = None  # type: ignore
+
+
+@pytest.mark.skipif(FaissHNSWIndex is None, reason="faiss not available")
+def test_forget_old_memories_respects_ttl(tmp_path) -> None:
+    async def _inner() -> None:
+        store = SQLiteMemoryStore(tmp_path / "mem.db")
+        await store.initialise()
+        index = FaissHNSWIndex(dim=3)
+        mem = Memory.new("old")
+        await store.add(mem)
+        vec = np.zeros((1, 3), dtype=np.float32)
+        index.add_vectors([mem.id], vec)
+        past = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=2)
+        await store.update_memory(mem.id, metadata={"last_accessed": past.isoformat()})
+        deleted = await forget_old_memories(
+            store,
+            index,
+            min_total=0,
+            retain_fraction=1.0,
+            ttl=60.0,
+        )
+        assert deleted == 1
+        assert await store.get(mem.id) is None
+        await store.aclose()
+
+    asyncio.run(_inner())
+
+
+@pytest.mark.skipif(FaissHNSWIndex is None, reason="faiss not available")
+def test_forget_old_memories_keeps_recent(tmp_path) -> None:
+    async def _inner() -> None:
+        store = SQLiteMemoryStore(tmp_path / "mem.db")
+        await store.initialise()
+        index = FaissHNSWIndex(dim=3)
+        mem = Memory.new("fresh")
+        await store.add(mem)
+        vec = np.zeros((1, 3), dtype=np.float32)
+        index.add_vectors([mem.id], vec)
+        await store.update_memory(mem.id, metadata={"last_accessed": dt.datetime.now(dt.timezone.utc).isoformat()})
+        deleted = await forget_old_memories(
+            store,
+            index,
+            min_total=0,
+            retain_fraction=1.0,
+            ttl=60.0,
+        )
+        assert deleted == 0
+        assert await store.get(mem.id) is not None
+        await store.aclose()
+
+    asyncio.run(_inner())

--- a/tests/test_last_accessed.py
+++ b/tests/test_last_accessed.py
@@ -1,0 +1,34 @@
+import asyncio
+
+from memory_system.core.store import Memory, SQLiteMemoryStore
+from memory_system.unified_memory import reinforce, update
+
+
+def test_update_writes_last_accessed(tmp_path) -> None:
+    async def _inner() -> None:
+        store = SQLiteMemoryStore(tmp_path / "mem.db")
+        await store.initialise()
+        mem = Memory.new("hi")
+        await store.add(mem)
+        await update(mem.id, text="hello", store=store)
+        loaded = await store.get(mem.id)
+        await store.aclose()
+        assert loaded is not None
+        assert "last_accessed" in (loaded.metadata or {})
+
+    asyncio.run(_inner())
+
+
+def test_reinforce_writes_last_accessed(tmp_path) -> None:
+    async def _inner() -> None:
+        store = SQLiteMemoryStore(tmp_path / "mem.db")
+        await store.initialise()
+        mem = Memory.new("hi")
+        await store.add(mem)
+        await reinforce(mem.id, 0.2, store=store)
+        loaded = await store.get(mem.id)
+        await store.aclose()
+        assert loaded is not None
+        assert "last_accessed" in (loaded.metadata or {})
+
+    asyncio.run(_inner())


### PR DESCRIPTION
## Summary
- record `last_accessed` timestamp whenever a memory is updated or reinforced
- add optional TTL handling to `forget_old_memories` to expire stale entries
- cover new behaviours with tests for last-access tracking and TTL expiry

## Testing
- `pytest tests/test_last_accessed.py tests/test_forget_ttl.py -q`
- `pre-commit run --files memory_system/unified_memory.py memory_system/core/maintenance.py tests/test_last_accessed.py tests/test_forget_ttl.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896e5f5b21c832590427e6708db2029