### PR TITLE
Add persistent score ranking

### DIFF
--- a/memory_system/api/routes/memory.py
+++ b/memory_system/api/routes/memory.py
@@ -87,21 +87,9 @@ async def search_memories(
 async def best_memories(
     request: Request,
     limit: int = Query(5, ge=1, le=50),
-    importance: float | None = Query(None, ge=0.0),
-    emotional_intensity: float | None = Query(None, ge=0.0),
-    valence_pos: float | None = Query(None, ge=0.0),
-    valence_neg: float | None = Query(None, ge=0.0),
 ) -> list[MemoryRead]:
     """Return the most important memories ranked by score."""
     store = await _store(request)
-    weights = None
-    if any(v is not None for v in (importance, emotional_intensity, valence_pos, valence_neg)):
-        weights = unified_memory.ListBestWeights(
-            importance=importance or 1.0,
-            emotional_intensity=emotional_intensity or 1.0,
-            valence_pos=valence_pos or 1.0,
-            valence_neg=valence_neg or 0.5,
-        )
-    records = await unified_memory.list_best(n=limit, store=store, weights=weights)
+    records = await unified_memory.list_best(n=limit, store=store)
     payload = [MemoryRead.model_validate(asdict(r)) for r in records]
     return payload

--- a/memory_system/core/store.py
+++ b/memory_system/core/store.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 # ────────────────────────── stdlib imports ──────────────────────────
 import asyncio
 import datetime as dt
-import heapq
 import inspect
 import json
 import logging
@@ -307,6 +306,17 @@ class SQLiteMemoryStore:
             conn = await self._acquire()
             try:
                 await conn.execute(self._CREATE_SQL)
+                await conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS memory_scores (
+                        memory_id TEXT PRIMARY KEY REFERENCES memories(id) ON DELETE CASCADE,
+                        score     REAL NOT NULL
+                    )
+                    """
+                )
+                await conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_memory_scores_score ON memory_scores(score)"
+                )
                 # Ensure FTS virtual table and triggers exist
                 await conn.executescript(
                     """
@@ -601,33 +611,45 @@ class SQLiteMemoryStore:
         finally:
             await self._release(conn)
 
-    async def top_n_by_score(
-        self,
-        n: int,
-        score_fn: Callable[[Memory], float],
-        *,
-        chunk_size: int = 1000,
-    ) -> List[Memory]:
-        """Return ``n`` memories with the highest ``score_fn`` values.
+    async def upsert_scores(self, scores: Sequence[tuple[str, float]]) -> None:
+        """Insert or update precomputed ranking *scores*.
 
-        The database is scanned in chunks to keep memory usage bounded while a
-        small in-memory heap maintains the top candidates.  This allows callers
-        to sample the *entire* store without loading every row at once.
+        Parameters
+        ----------
+        scores:
+            Sequence of ``(memory_id, score)`` pairs.
         """
+        if not scores:
+            return
+        await self.initialise()
+        conn = await self._acquire()
+        try:
+            await conn.executemany(
+                "INSERT INTO memory_scores(memory_id, score) VALUES (?, ?) "
+                "ON CONFLICT(memory_id) DO UPDATE SET score = excluded.score",
+                scores,
+            )
+            await conn.commit()
+            await self._run_commit_hooks()
+        finally:
+            await self._release(conn)
 
-        heap: list[tuple[float, Memory]] = []
-        async for batch in self.search_iter(limit=None, chunk_size=chunk_size):
-            for mem in batch:
-                score = score_fn(mem)
-                if len(heap) < n:
-                    heapq.heappush(heap, (score, mem))
-                else:
-                    # Maintain a min-heap of size ``n``
-                    if score > heap[0][0]:
-                        heapq.heapreplace(heap, (score, mem))
-
-        # Highest scores first
-        return [m for _, m in sorted(heap, key=lambda x: x[0], reverse=True)]
+    async def top_n_by_score(self, n: int) -> List[Memory]:
+        """Return ``n`` memories ordered by precomputed score."""
+        await self.initialise()
+        conn = await self._acquire()
+        try:
+            cursor = await conn.execute(
+                "SELECT m.id, m.text, m.created_at, m.importance, m.valence, "
+                "m.emotional_intensity, m.level, m.episode_id, m.modality, m.connections, m.metadata "
+                "FROM memory_scores s JOIN memories m ON m.id = s.memory_id "
+                "ORDER BY s.score DESC LIMIT ?",
+                (n,),
+            )
+            rows = await cursor.fetchall()
+            return [self._row_to_memory(r) for r in rows]
+        finally:
+            await self._release(conn)
 
     async def add_memory(self, mem_obj: Any) -> None:
         """Add a memory object, accepting either :class:`Memory` or a similar object."""

--- a/memory_system/unified_memory.py
+++ b/memory_system/unified_memory.py
@@ -30,7 +30,7 @@ from collections.abc import MutableMapping, Sequence
 
 # local
 from dataclasses import dataclass
-from typing import Any, Callable, Protocol
+from typing import Any, Protocol
 
 
 @dataclass(slots=True)
@@ -76,9 +76,9 @@ class MemoryStoreProtocol(Protocol):
 
     async def list_recent(self, *, n: int = 20) -> Sequence[Memory]: ...
 
-    async def top_n_by_score(
-        self, n: int, score_fn: Callable[[Memory], float]
-    ) -> Sequence[Memory]: ...
+    async def upsert_scores(self, scores: Sequence[tuple[str, float]]) -> None: ...
+
+    async def top_n_by_score(self, n: int) -> Sequence[Memory]: ...
 
 
 logger = logging.getLogger(__name__)
@@ -173,6 +173,12 @@ async def add(
     st = await _resolve_store(store)
     try:
         await asyncio.wait_for(st.add_memory(memory), timeout=ASYNC_TIMEOUT)
+        weights = _get_ranking_weights()
+        score = _score_best(memory, weights)
+        await asyncio.wait_for(
+            st.upsert_scores([(memory.memory_id, score)]),
+            timeout=ASYNC_TIMEOUT,
+        )
         logger.debug("Memory %s added (%d chars).", memory.memory_id, len(text))
     except Exception as e:
         logger.error("Failed to add memory: %s", e)
@@ -286,6 +292,12 @@ async def update(
             ),
             timeout=ASYNC_TIMEOUT,
         )
+        weights = _get_ranking_weights()
+        score = _score_best(updated, weights)
+        await asyncio.wait_for(
+            st.upsert_scores([(memory_id, score)]),
+            timeout=ASYNC_TIMEOUT,
+        )
         logger.debug("Memory %s updated.", memory_id)
     except Exception as e:
         logger.error("Update failed: %s", e)
@@ -331,6 +343,12 @@ async def reinforce(
                 emotional_intensity_delta=intensity_delta,
                 metadata=meta,
             ),
+            timeout=ASYNC_TIMEOUT,
+        )
+        weights = _get_ranking_weights()
+        score = _score_best(updated, weights)
+        await asyncio.wait_for(
+            st.upsert_scores([(memory_id, score)]),
             timeout=ASYNC_TIMEOUT,
         )
         logger.debug("Memory %s reinforced by %.2f.", memory_id, amount)
@@ -380,6 +398,17 @@ class ListBestWeights:
     valence_neg: float = 0.5
 
 
+def _get_ranking_weights() -> ListBestWeights:
+    """Load ranking weights from configuration if available."""
+    try:  # lazy import to avoid optional dependency at import time
+        from memory_system.config.settings import get_settings
+
+        cfg = get_settings()
+        return ListBestWeights(**cfg.ranking.model_dump())
+    except Exception:  # pragma: no cover - settings module optional
+        return ListBestWeights()
+
+
 def _score_best(m: Memory, weights: ListBestWeights) -> float:
     """Return the ranking score for a memory.
 
@@ -417,50 +446,19 @@ async def list_best(
     n: int = 5,
     *,
     store: MemoryStoreProtocol | None = None,
-    weights: ListBestWeights | None = None,
-    include_all: bool = False,
 ) -> Sequence[Memory]:
-    """Return *n* most important memories ranked by score.
+    """Return *n* memories with the highest precomputed score."""
 
-    Args:
-        n (int, optional): Number of top memories. Defaults to 5.
-        store (MemoryStoreProtocol | None, optional): Store object. Defaults to None.
-        weights (ListBestWeights | None, optional): Weight configuration for
-            ranking. Defaults to :class:`ListBestWeights`.
-        include_all (bool, optional): When ``True`` the whole store is scanned
-            using a priority queue instead of just the most recent entries.
-
-    Returns:
-        Sequence[Memory]: List of best memories ordered by score where
-        negative ``valence`` reduces the overall ranking.
-    """
     st = await _resolve_store(store)
-    if weights is None:
-        try:  # load from configuration if available
-            from memory_system.config.settings import get_settings
-
-            cfg = get_settings()
-            weights = ListBestWeights(**cfg.ranking.model_dump())
-        except Exception:  # pragma: no cover - settings module optional
-            weights = ListBestWeights()
     try:
-        if include_all:
-            # Attempt to leverage store-level optimisation for full scans
-            candidates = await asyncio.wait_for(
-                st.top_n_by_score(n, lambda m: _score_best(m, weights)),
-                timeout=ASYNC_TIMEOUT,
-            )
-            return [_ensure_memory(m) for m in candidates]
-
         candidates = await asyncio.wait_for(
-            st.list_recent(n=max(n * 5, 20)),
+            st.top_n_by_score(n),
             timeout=ASYNC_TIMEOUT,
         )
-        scored = sorted(candidates, key=lambda m: _score_best(m, weights), reverse=True)
     except Exception as e:
         logger.error("List best failed: %s", e)
         raise
-    return [_ensure_memory(m) for m in scored[:n]]
+    return [_ensure_memory(m) for m in candidates]
 
 
 __all__ = [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -482,13 +482,13 @@ class TestMemoryEndpoints:
         assert len(resp.json()) == 2
 
     def test_best_memories_custom_weights(self, test_client: TestClient, tmp_path: Path) -> None:
-        """Custom weights passed via query parameters should influence ranking."""
+        """Updating precomputed scores should change ranking."""
         import asyncio
         from memory_system.core.store import get_store
 
         loop = asyncio.get_event_loop()
         store = loop.run_until_complete(get_store(tmp_path / "api.db"))
-        loop.run_until_complete(
+        good = loop.run_until_complete(
             unified_memory.add(
                 "good",
                 valence=0.5,
@@ -497,7 +497,7 @@ class TestMemoryEndpoints:
                 store=store,
             )
         )
-        loop.run_until_complete(
+        bad = loop.run_until_complete(
             unified_memory.add(
                 "bad but vital",
                 valence=-0.5,
@@ -510,10 +510,21 @@ class TestMemoryEndpoints:
         resp_default = test_client.get("/api/v1/memory/best", params={"limit": 2})
         assert resp_default.json()[0]["text"] == "good"
 
-        resp_weighted = test_client.get(
-            "/api/v1/memory/best",
-            params={"limit": 2, "importance": 2.0},
+        weights = unified_memory.ListBestWeights(importance=2.0)
+
+        def _score(m):
+            val_w = weights.valence_pos if m.valence >= 0 else weights.valence_neg
+            return (
+                weights.importance * m.importance
+                + weights.emotional_intensity * m.emotional_intensity
+                + val_w * m.valence
+            )
+
+        loop.run_until_complete(
+            store.upsert_scores([(good.memory_id, _score(good)), (bad.memory_id, _score(bad))])
         )
+
+        resp_weighted = test_client.get("/api/v1/memory/best", params={"limit": 2})
         assert resp_weighted.json()[0]["text"] == "bad but vital"
 
 

--- a/tests/test_list_best.py
+++ b/tests/test_list_best.py
@@ -44,22 +44,23 @@ async def test_custom_weights_change_ranking(store):
     assert default_best[0].memory_id == pos.memory_id
 
     weights = mh.ListBestWeights(importance=2.0)
-    custom_best = await mh.list_best(n=2, store=store, weights=weights)
+
+    def _score(m):
+        val_w = weights.valence_pos if m.valence >= 0 else weights.valence_neg
+        return (
+            weights.importance * m.importance
+            + weights.emotional_intensity * m.emotional_intensity
+            + val_w * m.valence
+        )
+
+    await store.upsert_scores(
+        [
+            (pos.memory_id, _score(pos)),
+            (neg.memory_id, _score(neg)),
+        ]
+    )
+    custom_best = await mh.list_best(n=2, store=store)
     assert custom_best[0].memory_id == neg.memory_id
-
-
-@pytest.mark.asyncio
-async def test_include_all_scans_beyond_recent(store):
-    """When include_all is True older high-value memories surface."""
-    old = await um.add("ancient", importance=5.0, store=store)
-    for i in range(30):
-        await um.add(f"recent {i}", importance=0.1, store=store)
-
-    recent_only = await um.list_best(n=1, store=store)
-    assert recent_only[0].memory_id != old.memory_id
-
-    full_scan = await um.list_best(n=1, store=store, include_all=True)
-    assert full_scan[0].memory_id == old.memory_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `memory_scores` table with upsert helpers and SQL-based `top_n_by_score`
- compute and persist ranking scores on add/update/reinforce and simplify `list_best`
- simplify `/memory/best` API endpoint and update tests for precomputed ranking

## Testing
- `pytest tests/test_list_best.py` *(fails: async def functions are not natively supported)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_6896ea5f364483258db278b96d601817