### PR TITLE
Fix ruff lint errors and repair store logic

### DIFF
--- a/memory_system/api/routes/memory.py
+++ b/memory_system/api/routes/memory.py
@@ -90,9 +90,7 @@ async def search_memories(
 
 
 @router.patch("/{memory_id}", response_model=MemoryRead)
-async def update_memory(
-    memory_id: str, payload: MemoryUpdate, request: Request
-) -> MemoryRead:
+async def update_memory(memory_id: str, payload: MemoryUpdate, request: Request) -> MemoryRead:
     """Patch existing memory fields and metadata."""
     store = await _store(request)
     metadata: dict[str, Any] = {}
@@ -115,9 +113,7 @@ async def update_memory(
 
 
 @router.post("/{memory_id}/reinforce", response_model=MemoryRead)
-async def reinforce_memory(
-    memory_id: str, payload: MemoryReinforce, request: Request
-) -> MemoryRead:
+async def reinforce_memory(memory_id: str, payload: MemoryReinforce, request: Request) -> MemoryRead:
     """Reinforce a memory's scoring attributes."""
     store = await _store(request)
     updated = await unified_memory.reinforce(
@@ -136,7 +132,7 @@ async def best_memories(
     request: Request,
     n: int = Query(50, ge=1, le=500),
     importance: Optional[float] = Query(None, ge=0.0),
-    arousal: Optional[float] = Query(None, ge=0.0),          # alias для emotional_intensity
+    arousal: Optional[float] = Query(None, ge=0.0),  # alias для emotional_intensity
     valence_pos: Optional[float] = Query(None, ge=0.0),
     valence_neg: Optional[float] = Query(None, ge=0.0),
 ):

--- a/memory_system/api/schemas.py
+++ b/memory_system/api/schemas.py
@@ -33,7 +33,7 @@ class MemoryBase(BaseModel):
         0.0,
         ge=0.0,
         le=1.0,
-        description="Strength of emotional reaction"
+        description="Strength of emotional reaction",
         validation_alias=AliasChoices("arousal", "emotional_intensity"),
     )
     importance: float = Field(

--- a/memory_system/core/store.py
+++ b/memory_system/core/store.py
@@ -314,9 +314,7 @@ class SQLiteMemoryStore:
                     )
                     """
                 )
-                await conn.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_memory_scores_score ON memory_scores(score)"
-                )
+                await conn.execute("CREATE INDEX IF NOT EXISTS idx_memory_scores_score ON memory_scores(score)")
                 # Ensure FTS virtual table and triggers exist
                 await conn.executescript(
                     """
@@ -652,7 +650,7 @@ class SQLiteMemoryStore:
                     if limit is not None:
                         remaining = limit - fetched
                         if remaining <= 0:
-                        break
+                            break
                         batch_size = min(batch_size, remaining)
                     rows = await asyncio.to_thread(cursor._cursor.fetchmany, batch_size)
                     if not rows:
@@ -670,7 +668,10 @@ class SQLiteMemoryStore:
         conn = await self._acquire()
         try:
             params: tuple[Any, ...]
-            sql = "SELECT id, text, created_at, importance, valence, emotional_intensity, level, episode_id, modality, connections, metadata FROM memories"
+            sql = (
+                "SELECT id, text, created_at, importance, valence, emotional_intensity, level, "
+                "episode_id, modality, connections, metadata FROM memories"
+            )
             if level is not None:
                 sql += " WHERE level = ? ORDER BY created_at DESC LIMIT ?"
                 params = (level, n)
@@ -679,40 +680,7 @@ class SQLiteMemoryStore:
                 params = (n,)
             cursor = await conn.execute(sql, params)
             rows = await cursor.fetchall()
-            return [self._row_to_memory("""Yield search results in chunks to keep memory usage bounded.
-
-        Results are streamed using a SQLite cursor and ``fetchmany`` to avoid
-        loading the entire result set into memory. Additional filters allow
-        callers to restrict the range of levels via ``min_level`` and to
-        include only memories marked as final or not via ``final``.
-        """
-
-        await self.initialise()
-        conn = await self._acquire()
-        try:
-            params: list[Any] = []
-            if text_query:
-                sql = (
-                    "SELECT m.id, m.text, m.created_at, m.importance, m.valence, "
-                    "m.emotional_intensity, m.level, m.episode_id, m.modality, m.connections, m.metadata "
-                    "FROM memories_fts JOIN memories m ON m.rowid = memories_fts.rowid "
-                    "WHERE memories_fts MATCH ?"
-                )
-                params.append(text_query)
-                if metadata_filters:
-                    for key, val in metadata_filters.items():
-                        if key in {"episode_id", "modality"}:
-                            sql += f" AND m.{key} = ?"
-                            params.append(val)
-                        else:
-                            sql += " AND json_extract(m.metadata, ?) = ?"
-                            params.extend([f"$.{key}", val])
-                if level is not None:
-                    sql += " AND m.level = ?"
-                    params.append(level)
-                if min_level is not None:
-                    sql += " AND m.level >= ?"
-                    params.append(min_level)r) for r in rows]
+            return [self._row_to_memory(r) for r in rows]
         finally:
             await self._release(conn)
 
@@ -840,9 +808,7 @@ class SQLiteMemoryStore:
                 )
             elif importance_delta is not None:
                 await conn.execute(
-                    "UPDATE memories "
-                    "SET importance = MAX(0.0, MIN(1.0, importance + ?)) "
-                    "WHERE id = ?",
+                    "UPDATE memories SET importance = MAX(0.0, MIN(1.0, importance + ?)) WHERE id = ?",
                     (importance_delta, memory_id),
                 )
 
@@ -853,9 +819,7 @@ class SQLiteMemoryStore:
                 )
             elif valence_delta is not None:
                 await conn.execute(
-                    "UPDATE memories "
-                    "SET valence = MAX(-1.0, MIN(1.0, valence + ?)) "
-                    "WHERE id = ?",
+                    "UPDATE memories SET valence = MAX(-1.0, MIN(1.0, valence + ?)) WHERE id = ?",
                     (valence_delta, memory_id),
                 )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -484,6 +484,7 @@ class TestMemoryEndpoints:
     def test_best_memories_custom_weights(self, test_client: TestClient, tmp_path: Path) -> None:
         """Updating precomputed scores should change ranking."""
         import asyncio
+
         from memory_system.core.store import get_store
 
         loop = asyncio.get_event_loop()
@@ -520,9 +521,7 @@ class TestMemoryEndpoints:
                 + val_w * m.valence
             )
 
-        loop.run_until_complete(
-            store.upsert_scores([(good.memory_id, _score(good)), (bad.memory_id, _score(bad))])
-        )
+        loop.run_until_complete(store.upsert_scores([(good.memory_id, _score(good)), (bad.memory_id, _score(bad))]))
 
         resp_weighted = test_client.get("/api/v1/memory/best", params={"limit": 2})
         assert resp_weighted.json()[0]["text"] == "bad but vital"

--- a/tests/test_forget_ttl.py
+++ b/tests/test_forget_ttl.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime as dt
+
 import pytest
 
 np = pytest.importorskip("numpy")

--- a/tests/test_list_best.py
+++ b/tests/test_list_best.py
@@ -31,7 +31,7 @@ async def test_negative_can_surface_when_important(store):
 @pytest.mark.asyncio
 async def test_custom_weights_change_ranking(store):
     """Custom weights allow tweaking ranking behaviour."""
-    pos = await um.add("good", valence=0.5, emotional_intensity=1.0, importance=1.0, store=store)
+    await um.add("good", valence=0.5, emotional_intensity=1.0, importance=1.0, store=store)
     neg = await um.add(
         "bad but vital",
         valence=-0.5,
@@ -48,9 +48,7 @@ async def test_custom_weights_change_ranking(store):
     def _score(m):
         val_w = weights.valence_pos if m.valence >= 0 else weights.valence_neg
         return (
-            weights.importance * m.importance
-            + weights.emotional_intensity * m.emotional_intensity
-            + val_w * m.valence
+            weights.importance * m.importance + weights.emotional_intensity * m.emotional_intensity + val_w * m.valence
         )
 
     await store.upsert_scores(
@@ -72,7 +70,13 @@ async def test_config_weights_change_ranking(monkeypatch, store):
     settings.ranking = RankingConfig(importance=2.0)
     monkeypatch.setattr("memory_system.config.settings.get_settings", lambda env=None: settings)
 
-    pos = await um.add("good", valence=0.5, emotional_intensity=1.0, importance=1.0, store=store)
+    await um.add(
+        "good",
+        valence=0.5,
+        emotional_intensity=1.0,
+        importance=1.0,
+        store=store,
+    )
     neg = await um.add(
         "bad but vital",
         valence=-0.5,


### PR DESCRIPTION
## Summary
- fix `MemoryBase` arousal field syntax and alias
- repair search iteration and `list_recent` in SQLite store
- tidy imports and unused variables in tests

## Testing
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6896f5099b60832589268cbfd36a7d56