### PR TITLE
feat: expose filtering for best-memory endpoint

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,10 +33,12 @@ The `/api/v1/memory/best` endpoint scores memories using weighted attributes:
 
 Defaults are configured via `RankingConfig` and may be overridden with
 environment variables such as `AI_RANKING__IMPORTANCE=2.0`.
-Per-request weights can be supplied as query parameters:
+Per-request weights can be supplied as query parameters.  Results may also
+be limited to a specific ``level`` or filtered by metadata fields such as
+``user_id``:
 
 ```bash
-curl "http://localhost:8000/api/v1/memory/best?limit=2&importance=2.0&valence_neg=1.0"
+curl "http://localhost:8000/api/v1/memory/best?limit=2&level=1&user_id=42&importance=2.0&valence_neg=1.0"
 ```
 
 ## Database Encryption

--- a/memory_system/api/routes/memory.py
+++ b/memory_system/api/routes/memory.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import logging
 import uuid
 from dataclasses import asdict
-from typing import Any, cast
+from typing import Any, Optional, cast
 
 from fastapi import APIRouter, HTTPException, Query, Request, status
 
 from memory_system import unified_memory
+from memory_system.unified_memory import ListBestWeights
 from memory_system.api.schemas import (
     MemoryCreate,
     MemoryQuery,
@@ -130,13 +131,16 @@ async def reinforce_memory(memory_id: str, payload: MemoryReinforce, request: Re
 @router.get("/best", response_model=list[MemoryRead])
 async def best_memories(
     request: Request,
-    n: int = Query(50, ge=1, le=500),
+    n: int = Query(50, ge=1, le=500, alias="limit"),
+    level: int | None = Query(None, ge=0),
+    user_id: str | None = Query(None),
     importance: Optional[float] = Query(None, ge=0.0),
     arousal: Optional[float] = Query(None, ge=0.0),  # alias для emotional_intensity
     valence_pos: Optional[float] = Query(None, ge=0.0),
     valence_neg: Optional[float] = Query(None, ge=0.0),
 ):
     store = await _store(request)
+    meta = {"user_id": user_id} if user_id else None
 
     weights = None
     if any(v is not None for v in (importance, arousal, valence_pos, valence_neg)):
@@ -147,6 +151,12 @@ async def best_memories(
             valence_neg=valence_neg or 0.5,
         )
 
-    records = await unified_memory.list_best(n=n, store=store, weights=weights)
+    records = await unified_memory.list_best(
+        n=n,
+        store=store,
+        level=level,
+        metadata_filter=meta,
+        weights=weights,
+    )
     payload = [MemoryRead.model_validate(asdict(r)) for r in records]
     return payload

--- a/memory_system/core/store.py
+++ b/memory_system/core/store.py
@@ -19,7 +19,7 @@ from collections.abc import AsyncIterator
 # ───────────────────────── local imports ───────────────────────────
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, MutableMapping, Optional, Sequence, cast
 
 # ─────────────────────── third-party imports ───────────────────────
 import aiosqlite
@@ -707,18 +707,51 @@ class SQLiteMemoryStore:
         finally:
             await self._release(conn)
 
-    async def top_n_by_score(self, n: int) -> List[Memory]:
-        """Return ``n`` memories ordered by precomputed score."""
+    async def top_n_by_score(
+        self,
+        n: int,
+        *,
+        level: int | None = None,
+        metadata_filter: MutableMapping[str, Any] | None = None,
+    ) -> List[Memory]:
+        """Return ``n`` memories ordered by precomputed score.
+
+        Parameters
+        ----------
+        n:
+            Number of memories to return.
+        level:
+            Optional exact level filter.
+        metadata_filter:
+            Mapping of metadata key/value pairs that must all match.
+        """
+
         await self.initialise()
         conn = await self._acquire()
         try:
-            cursor = await conn.execute(
+            clauses: list[str] = []
+            params: list[Any] = []
+            if level is not None:
+                clauses.append("m.level = ?")
+                params.append(level)
+            if metadata_filter:
+                for key, val in metadata_filter.items():
+                    if key in {"episode_id", "modality"}:
+                        clauses.append(f"m.{key} = ?")
+                        params.append(val)
+                    else:
+                        clauses.append("json_extract(m.metadata, ?) = ?")
+                        params.extend([f"$.{key}", val])
+            sql = (
                 "SELECT m.id, m.text, m.created_at, m.importance, m.valence, "
                 "m.emotional_intensity, m.level, m.episode_id, m.modality, m.connections, m.metadata "
-                "FROM memory_scores s JOIN memories m ON m.id = s.memory_id "
-                "ORDER BY s.score DESC LIMIT ?",
-                (n,),
+                "FROM memory_scores s JOIN memories m ON m.id = s.memory_id"
             )
+            if clauses:
+                sql += " WHERE " + " AND ".join(clauses)
+            sql += " ORDER BY s.score DESC LIMIT ?"
+            params.append(n)
+            cursor = await conn.execute(sql, params)
             rows = await cursor.fetchall()
             return [self._row_to_memory(r) for r in rows]
         finally:

--- a/memory_system/unified_memory.py
+++ b/memory_system/unified_memory.py
@@ -78,7 +78,13 @@ class MemoryStoreProtocol(Protocol):
 
     async def upsert_scores(self, scores: Sequence[tuple[str, float]]) -> None: ...
 
-    async def top_n_by_score(self, n: int) -> Sequence[Memory]: ...
+    async def top_n_by_score(
+        self,
+        n: int,
+        *,
+        level: int | None = None,
+        metadata_filter: MutableMapping[str, Any] | None = None,
+    ) -> Sequence[Memory]: ...
 
 
 logger = logging.getLogger(__name__)
@@ -446,13 +452,35 @@ async def list_best(
     n: int = 5,
     *,
     store: MemoryStoreProtocol | None = None,
+    level: int | None = None,
+    metadata_filter: MutableMapping[str, Any] | None = None,
+    weights: ListBestWeights | None = None,
 ) -> Sequence[Memory]:
-    """Return *n* memories with the highest precomputed score."""
+    """Return *n* memories with the highest precomputed score.
+
+    Parameters
+    ----------
+    n:
+        Number of memories to return.
+    store:
+        Optional explicit memory store.
+    level:
+        Optional level filter applied before ranking.
+    metadata_filter:
+        Additional metadata constraints, matched exactly.
+    weights:
+        Present for backwards compatibility; currently ignored as scores
+        are precomputed when memories are stored.
+    """
 
     st = await _resolve_store(store)
     try:
         candidates = await asyncio.wait_for(
-            st.top_n_by_score(n),
+            st.top_n_by_score(
+                n,
+                level=level,
+                metadata_filter=metadata_filter,
+            ),
             timeout=ASYNC_TIMEOUT,
         )
     except Exception as e:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -481,6 +481,28 @@ class TestMemoryEndpoints:
         assert resp.status_code == 200
         assert len(resp.json()) == 2
 
+    def test_best_memories_level_and_filter(self, test_client: TestClient) -> None:
+        """Level and metadata filters should narrow results."""
+        import asyncio
+        from memory_system.core.store import Memory as StoreMemory
+
+        store = test_client.app.state.store
+        loop = asyncio.get_event_loop()
+        m0 = StoreMemory(id="m0", text="base", level=0, metadata={"user_id": "u1"})
+        m1 = StoreMemory(id="m1", text="lvl1", level=1, metadata={"user_id": "u2"})
+        loop.run_until_complete(store.add_memory(m0))
+        loop.run_until_complete(store.add_memory(m1))
+        loop.run_until_complete(store.upsert_scores([(m0.id, 0.1), (m1.id, 0.2)]))
+
+        resp = test_client.get(
+            "/api/v1/memory/best",
+            params={"limit": 5, "level": 1, "user_id": "u2"},
+        )
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert len(payload) == 1
+        assert payload[0]["id"] == "m1"
+
     def test_best_memories_custom_weights(self, test_client: TestClient, tmp_path: Path) -> None:
         """Updating precomputed scores should change ranking."""
         import asyncio

--- a/tests/test_list_best.py
+++ b/tests/test_list_best.py
@@ -4,6 +4,7 @@ import pytest
 
 from memory_system import memory_helpers as mh
 from memory_system import unified_memory as um
+from memory_system.core.store import Memory as StoreMemory
 
 
 @pytest.mark.asyncio
@@ -31,7 +32,7 @@ async def test_negative_can_surface_when_important(store):
 @pytest.mark.asyncio
 async def test_custom_weights_change_ranking(store):
     """Custom weights allow tweaking ranking behaviour."""
-    await um.add("good", valence=0.5, emotional_intensity=1.0, importance=1.0, store=store)
+    pos = await um.add("good", valence=0.5, emotional_intensity=1.0, importance=1.0, store=store)
     neg = await um.add(
         "bad but vital",
         valence=-0.5,
@@ -87,3 +88,19 @@ async def test_config_weights_change_ranking(monkeypatch, store):
 
     best = await um.list_best(n=2, store=store)
     assert best[0].memory_id == neg.memory_id
+
+
+@pytest.mark.asyncio
+async def test_level_and_metadata_filters(store):
+    """`list_best` should respect level and metadata filters."""
+    mem0 = StoreMemory(id="m0", text="base", level=0, metadata={"user_id": "u1"})
+    mem1 = StoreMemory(id="m1", text="lvl1", level=1, metadata={"user_id": "u2"})
+    await store.add_memory(mem0)
+    await store.add_memory(mem1)
+    await store.upsert_scores([(mem0.id, 0.1), (mem1.id, 0.2)])
+
+    best_lvl1 = await um.list_best(n=5, store=store, level=1)
+    assert [m.memory_id for m in best_lvl1] == [mem1.id]
+
+    best_user = await um.list_best(n=5, store=store, metadata_filter={"user_id": "u1"})
+    assert [m.memory_id for m in best_user] == [mem0.id]


### PR DESCRIPTION
## Summary
- allow listing best memories by level and metadata filter
- support level and user filters on `/api/v1/memory/best`
- document and test usage

## Testing
- `pytest tests/test_list_best.py::test_level_and_metadata_filters -q` *(fails: async plugin missing)*
- `pytest tests/test_api.py::TestMemoryEndpoints::test_best_memories_level_and_filter -q` *(fails: No module named 'httpx')*
- `pre-commit run --files memory_system/unified_memory.py memory_system/core/store.py memory_system/api/routes/memory.py tests/test_list_best.py tests/test_api.py docs/index.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896fa5e6a94832592a145f0f211359c