### PR TITLE
feat: allow absolute emotional updates

### DIFF
--- a/memory_system/api/routes/memory.py
+++ b/memory_system/api/routes/memory.py
@@ -105,7 +105,9 @@ async def update_memory(memory_id: str, payload: MemoryUpdate, request: Request)
         metadata=metadata or None,
         importance=payload.importance,
         importance_delta=payload.importance_delta,
+        valence=payload.valence,
         valence_delta=payload.valence_delta,
+        emotional_intensity=payload.arousal,
         emotional_intensity_delta=payload.arousal_delta,
         store=store,
     )

--- a/memory_system/api/schemas.py
+++ b/memory_system/api/schemas.py
@@ -71,25 +71,47 @@ class MemoryCreate(MemoryBase):
 
 
 class MemoryUpdate(BaseModel):
-    """Payload for partial updates where all fields are optional."""
+    """Payload for partial updates where all fields are optional.
+
+    ``valence``, ``arousal`` and ``importance`` replace the existing values
+    directly, whereas the ``*_delta`` counterparts add to the current value.
+    """
 
     text: str | None = Field(default=None, min_length=1, max_length=10_000)
     role: str | None = Field(default=None, max_length=32)
     tags: list[str] | None = Field(default=None, max_length=10)
-    valence: float | None = Field(default=None, ge=-1.0, le=1.0)
+    valence: float | None = Field(
+        default=None,
+        ge=-1.0,
+        le=1.0,
+        description="Set absolute valence value",
+    )
     arousal: float | None = Field(
         default=None,
         ge=0.0,
         le=1.0,
         validation_alias=AliasChoices("arousal", "emotional_intensity"),
+        description="Set absolute arousal/emotional intensity",
     )
-    importance: float | None = Field(default=None, ge=0.0, le=1.0)
-    valence_delta: float | None = Field(default=None)
+    importance: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Set absolute importance",
+    )
+    valence_delta: float | None = Field(
+        default=None,
+        description="Increment to apply to current valence",
+    )
     arousal_delta: float | None = Field(
         default=None,
         validation_alias=AliasChoices("arousal_delta", "emotional_intensity_delta"),
+        description="Increment to apply to current arousal",
     )
-    importance_delta: float | None = Field(default=None)
+    importance_delta: float | None = Field(
+        default=None,
+        description="Increment to apply to current importance",
+    )
 
     model_config = {
         "extra": "forbid",

--- a/memory_system/core/store.py
+++ b/memory_system/core/store.py
@@ -818,12 +818,13 @@ class SQLiteMemoryStore:
         emotional_intensity_delta: float | None = None,
     ) -> Memory:
         """
-        Update text, importance, valence, emotional_intensity and/or metadata.
+        Update text, scores and metadata.
 
-        Absolute fields (``importance``, ``valence``, ``emotional_intensity``)
-        are written directly (clamped). ``*_delta`` fields increment current
-        values (also clamped). Metadata is shallow-merged as JSON.
-        Ranges: importance ∈ [0,1], emotional_intensity ∈ [0,1], valence ∈ [-1,1].
+        ``importance``, ``valence`` and ``emotional_intensity`` set new values
+        for the respective fields (after clamping to their ranges).  The
+        ``*_delta`` counterparts add the provided amount to the current value,
+        also clamped.  Metadata is shallow‑merged as JSON.  Ranges:
+        importance ∈ [0,1], emotional_intensity ∈ [0,1], valence ∈ [-1,1].
         """
         await self.initialise()
         conn = await self._acquire()

--- a/memory_system/unified_memory.py
+++ b/memory_system/unified_memory.py
@@ -72,7 +72,14 @@ class MemoryStoreProtocol(Protocol):
         valence_delta: float | None = None,
         emotional_intensity: float | None = None,
         emotional_intensity_delta: float | None = None,
-    ) -> Memory: ...
+    ) -> Memory:
+        """Update fields or scores of a memory.
+
+        Absolute parameters overwrite stored values while ``*_delta`` fields
+        apply relative adjustments.
+        """
+
+        ...
 
     async def list_recent(self, *, n: int = 20) -> Sequence[Memory]: ...
 
@@ -254,7 +261,9 @@ async def update(
     metadata: MutableMapping[str, Any] | None = None,
     importance: float | None = None,
     importance_delta: float | None = None,
+    valence: float | None = None,
     valence_delta: float | None = None,
+    emotional_intensity: float | None = None,
     emotional_intensity_delta: float | None = None,
     store: MemoryStoreProtocol | None = None,
 ) -> Memory:
@@ -265,7 +274,9 @@ async def update(
     ``importance_delta``.
 
     ``last_accessed`` in the memory's metadata is automatically set to the
-    current UTC timestamp.
+    current UTC timestamp.  Absolute ``valence`` and ``emotional_intensity``
+    values may be supplied to overwrite existing ones while the ``*_delta``
+    counterparts adjust the stored values.
 
     Args:
         memory_id (str): The memory identifier.
@@ -273,7 +284,10 @@ async def update(
         metadata (MutableMapping[str, Any] | None, optional): New metadata. Defaults to None.
         importance (float | None, optional): New importance value. Defaults to None.
         importance_delta (float | None, optional): Increment for importance. Defaults to None.
+        valence (float | None, optional): New emotional valence. Defaults to None.
         valence_delta (float | None, optional): Increment for emotional valence.
+            Defaults to None.
+        emotional_intensity (float | None, optional): New emotional intensity.
             Defaults to None.
         emotional_intensity_delta (float | None, optional): Increment for
             emotional intensity. Defaults to None.
@@ -293,7 +307,9 @@ async def update(
                 metadata=meta,
                 importance=importance,
                 importance_delta=importance_delta,
+                valence=valence,
                 valence_delta=valence_delta,
+                emotional_intensity=emotional_intensity,
                 emotional_intensity_delta=emotional_intensity_delta,
             ),
             timeout=ASYNC_TIMEOUT,

--- a/tests/test_store_ext.py
+++ b/tests/test_store_ext.py
@@ -302,3 +302,24 @@ def test_unified_update_sets_importance(store: SQLiteMemoryStore) -> None:
         assert abs(updated.importance - 0.8) < 1e-6
 
     asyncio.run(_run())
+
+
+def test_unified_update_sets_emotions(store: SQLiteMemoryStore) -> None:
+    async def _run() -> None:
+        async def noop(_: list[tuple[str, float]]) -> None:
+            return None
+
+        store.upsert_scores = noop  # type: ignore[assignment]
+
+        mem = Memory.new("hi", valence=0.1, emotional_intensity=0.2)
+        await store.add(mem)
+        updated = await um_update(
+            mem.id,
+            valence=-0.5,
+            emotional_intensity=0.9,
+            store=store,
+        )
+        assert updated.valence == pytest.approx(-0.5)
+        assert updated.emotional_intensity == pytest.approx(0.9)
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- forward `valence` and `arousal` in memory update API
- support absolute `valence` and `emotional_intensity` in unified memory update
- document differences between absolute values and delta adjustments
- add tests for updating emotional fields directly

## Testing
- `pytest tests/test_store_ext.py::test_unified_update_sets_emotions -q`
- `pre-commit run --files memory_system/api/routes/memory.py memory_system/api/schemas.py memory_system/unified_memory.py memory_system/core/store.py tests/test_store_ext.py` *(fails: pre-commit: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689700ec705c8325a1ac03c887e51e1e