### PR TITLE
Refactor EnhancedMemoryStore startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ settings = UnifiedSettings.for_testing()
 store = EnhancedMemoryStore(settings)
 
 async def demo():
+    await store.start()
     await store.add_memory(text="Hello world!", embedding=np.random.rand(settings.model.vector_dim).tolist())
     hits = await store.semantic_search(
         vector=np.random.rand(settings.model.vector_dim).tolist(), k=3, return_distance=True

--- a/memory_system/api/app.py
+++ b/memory_system/api/app.py
@@ -196,6 +196,7 @@ def create_app(settings: UnifiedSettings | None = None) -> FastAPI:  # pragma: n
     @app.on_event("startup")
     async def _startup() -> None:
         store = EnhancedMemoryStore(settings)
+        await store.start()
         app.state.store = store
         app.state.memory_store = store
         # Dependency bridge ----------------------------------------------------

--- a/memory_system/api/dependencies.py
+++ b/memory_system/api/dependencies.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import functools
 import logging
 import typing
@@ -33,7 +34,12 @@ def get_settings() -> UnifiedSettings:
 @functools.lru_cache
 def get_memory_store() -> EnhancedMemoryStore:
     """Provide a cached EnhancedMemoryStore instance (singleton)."""
-    return EnhancedMemoryStore(get_settings())  # Note: runs in sync for simplicity
+    store = EnhancedMemoryStore(get_settings())  # Note: runs in sync for simplicity
+    try:
+        asyncio.get_running_loop().create_task(store.start())
+    except RuntimeError:
+        pass
+    return store
 
 
 @functools.lru_cache

--- a/memory_system/api/routes/health.py
+++ b/memory_system/api/routes/health.py
@@ -39,7 +39,10 @@ if hasattr(router, "add_exception_handler"):
 
 async def _store() -> EnhancedMemoryStore:
     """Dependency to get the global EnhancedMemoryStore (async)."""
-    return get_memory_store()
+    store = get_memory_store()
+    if getattr(store, "_monitor_task", None) is None:
+        await store.start()
+    return store
 
 
 def _settings() -> UnifiedSettings:

--- a/memory_system/core/enhanced_store.py
+++ b/memory_system/core/enhanced_store.py
@@ -144,7 +144,12 @@ class EnhancedMemoryStore:
         self._monitor_interval = 60.0
         self._min_ef_search = max(16, settings.model.hnsw_ef_search // 2)
         self._max_ef_search = settings.model.hnsw_ef_search * 4
-        self._monitor_task = asyncio.create_task(self._monitor_recall_loop())
+        self._monitor_task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        """Start background tasks for the store."""
+        loop = asyncio.get_running_loop()
+        self._monitor_task = loop.create_task(self._monitor_recall_loop())
 
     async def get_health(self) -> HealthComponent:
         """Get health status."""
@@ -188,9 +193,10 @@ class EnhancedMemoryStore:
 
     async def close(self) -> None:
         """Close the store."""
-        self._monitor_task.cancel()
-        with suppress(Exception):
-            await self._monitor_task
+        if self._monitor_task:
+            self._monitor_task.cancel()
+            with suppress(Exception):
+                await self._monitor_task
         await self._store.aclose()
         self._closed = True
 

--- a/tests/test_benchmark_regression.py
+++ b/tests/test_benchmark_regression.py
@@ -29,6 +29,7 @@ EMBEDDING = np.random.rand(DIM).astype("float32").tolist()
 @pytest_asyncio.fixture(scope="session")
 async def bench_store() -> AsyncGenerator[EnhancedMemoryStore, None]:
     s = EnhancedMemoryStore(UnifiedSettings.for_testing())
+    await s.start()
     for _ in range(1_000):
         await s.add_memory(text="bench", embedding=np.random.rand(DIM).tolist())
     yield s

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,11 +6,12 @@ import struct
 import tempfile
 import time
 from pathlib import Path
-from typing import Generator, Iterator
+from typing import AsyncIterator, Generator, Iterator
 from unittest.mock import patch
 
 import numpy as np
 import pytest
+import pytest_asyncio
 
 from memory_system.config.settings import UnifiedSettings
 from memory_system.core.embedding import (
@@ -199,16 +200,18 @@ class TestEnhancedMemoryStore:
         """Create test settings."""
         return UnifiedSettings.for_testing()
 
-    @pytest.fixture
-    def store(self, test_settings: UnifiedSettings) -> Iterator[EnhancedMemoryStore]:
+    @pytest_asyncio.fixture
+    async def store(self, test_settings: UnifiedSettings) -> AsyncIterator[EnhancedMemoryStore]:
         """Create EnhancedMemoryStore instance and ensure closure."""
         store = EnhancedMemoryStore(test_settings)
+        await store.start()
         try:
             yield store
         finally:
-            asyncio.run(store.close())
+            await store.close()
 
-    def test_store_initialization(self, store: EnhancedMemoryStore, test_settings: UnifiedSettings) -> None:
+    @pytest.mark.asyncio
+    async def test_store_initialization(self, store: EnhancedMemoryStore, test_settings: UnifiedSettings) -> None:
         """Test store initialization."""
         assert store.settings == test_settings
         assert store._start_time > 0
@@ -847,6 +850,7 @@ class TestCoreIntegration:
     async def test_store_and_embedding_integration(self, test_settings: UnifiedSettings) -> None:
         """Test integration between store and embedding service."""
         store = EnhancedMemoryStore(test_settings)
+        await store.start()
         embedding_service = EnhancedEmbeddingService("all-MiniLM-L6-v2", test_settings)
         try:
             # Test that both components can work together
@@ -879,6 +883,7 @@ class TestCoreIntegration:
     async def test_error_handling_integration(self, test_settings: UnifiedSettings) -> None:
         """Test error handling across components."""
         store = EnhancedMemoryStore(test_settings)
+        await store.start()
         try:
             # Test error handling: close the store and then try to use a method that should fail
             await store.close()

--- a/tests/test_db_invariants.py
+++ b/tests/test_db_invariants.py
@@ -22,6 +22,7 @@ async def test_db_invariants(tmp_path: Path) -> None:
     # Replace database configuration with a new path
     cfg.database = DatabaseConfig(db_path=tmp_path / "inv.db")
     store = EnhancedMemoryStore(cfg)
+    await store.start()
 
     await store.add_memory(text="inv", embedding=np.random.rand(DIM).tolist())
 
@@ -49,3 +50,4 @@ async def test_db_invariants(tmp_path: Path) -> None:
 
     # vector index dimension must match config
     assert store._index.stats().dim == DIM
+    await store.close()

--- a/tests/test_encryption_at_rest.py
+++ b/tests/test_encryption_at_rest.py
@@ -21,6 +21,7 @@ async def test_sqlcipher_encryption(tmp_path: Path) -> None:
     cfg.security = cfg.security.model_copy(update={"encrypt_at_rest": True})
 
     store = EnhancedMemoryStore(cfg)
+    await store.start()
     await store.add_memory(text="secret-string", embedding=[0.0] * cfg.model.vector_dim)
     await store.close()
 

--- a/tests/test_enhanced_store.py
+++ b/tests/test_enhanced_store.py
@@ -26,8 +26,11 @@ async def store() -> AsyncGenerator[EnhancedMemoryStore, None]:
     """Provide an EnhancedMemoryStore instance for testing."""
     settings = UnifiedSettings.for_testing()
     s = EnhancedMemoryStore(settings)
-    yield s
-    await s.close()
+    await s.start()
+    try:
+        yield s
+    finally:
+        await s.close()
 
 
 def _rand_embedding(dim: int, seed: int = 42) -> list[float]:
@@ -95,6 +98,7 @@ async def test_invalid_embedding_length(store: EnhancedMemoryStore) -> None:
 async def test_semantic_search_filters_by_level_and_is_faster(monkeypatch: pytest.MonkeyPatch) -> None:
     settings = UnifiedSettings.for_testing()
     store = EnhancedMemoryStore(settings)
+    await store.start()
 
     dim = store.settings.model.vector_dim
     emb0 = np.random.rand(dim).astype("float32").tolist()

--- a/tests/test_enhanced_store_impl.py
+++ b/tests/test_enhanced_store_impl.py
@@ -15,6 +15,7 @@ async def test_enhanced_store_add_search_list_stats(tmp_path: Path) -> None:
     os.environ["DATABASE__VEC_PATH"] = str(tmp_path / "mem.vectors")
     settings = UnifiedSettings.for_testing()
     store = EnhancedMemoryStore(settings)
+    await store.start()
     try:
         vec_dim = settings.model.vector_dim
         emb1 = list(np.random.rand(vec_dim).astype(np.float32))
@@ -65,6 +66,7 @@ async def test_enhanced_store_add_search_list_stats(tmp_path: Path) -> None:
     assert settings.database.vec_path.exists()
 
     store = EnhancedMemoryStore(settings)
+    await store.start()
     try:
         results_after_reload = await store.semantic_search(embedding=emb1, k=1)
         assert results_after_reload and results_after_reload[0].id == mem1.id

--- a/tests/test_hypothesis_vectors.py
+++ b/tests/test_hypothesis_vectors.py
@@ -39,8 +39,11 @@ def _float32_arrays() -> SearchStrategy[List[float]]:
 async def store() -> AsyncGenerator[EnhancedMemoryStore, None]:
     """Create an EnhancedMemoryStore instance for testing."""
     s = EnhancedMemoryStore(UnifiedSettings.for_testing())
-    yield s
-    await s.close()
+    await s.start()
+    try:
+        yield s
+    finally:
+        await s.close()
 
 
 @given(vec=_float32_arrays())

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -36,6 +36,7 @@ class TestEndToEndMemoryWorkflow:
 
         # Create components
         store = EnhancedMemoryStore(settings)
+        await store.start()
         embedding_service = EnhancedEmbeddingService("all-MiniLM-L6-v2", settings)
 
         # Create temporary paths

--- a/tests/test_multi_modality.py
+++ b/tests/test_multi_modality.py
@@ -26,6 +26,7 @@ async def test_enhanced_store_multi_modality(tmp_path):
     object.__setattr__(settings.database, "vec_path", tmp_path / "memory.vectors")
 
     store = EnhancedMemoryStore(settings)
+    await store.start()
     await store.add_memory(text="hello", embedding=[0.1] * settings.model.vector_dims["text"], modality="text")
     await store.add_memory(text="picture", embedding=[0.1, 0.2, 0.3], modality="image")
 

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -587,6 +587,7 @@ async def test_dynamic_ef_search_tuning() -> None:
     """Ensure ef_search adapts based on recall measurements."""
     settings = UnifiedSettings.for_testing()
     store = EnhancedMemoryStore(settings)
+    await store.start()
     try:
         vec = np.random.rand(settings.model.vector_dim).astype(np.float32)
         mem = await store.add_memory(text="probe", embedding=vec.tolist())

--- a/tests/test_precision_at_k.py
+++ b/tests/test_precision_at_k.py
@@ -24,6 +24,7 @@ def near(embedding: List[float], eps: float = 0.0) -> List[float]:
 async def test_precision_at_k(tmp_path: Path) -> None:
     cfg = UnifiedSettings.for_testing()
     store = EnhancedMemoryStore(cfg)
+    await store.start()
 
     # create 20 clusters of similar embeddings
     base = [np.random.rand(EMBEDDING_DIM).tolist() for _ in range(20)]
@@ -41,3 +42,4 @@ async def test_precision_at_k(tmp_path: Path) -> None:
 
     precision = hits / total
     assert precision >= 0.2
+    await store.close()

--- a/tests/test_semantic_search_benchmark.py
+++ b/tests/test_semantic_search_benchmark.py
@@ -31,6 +31,7 @@ async def populated_store() -> AsyncGenerator[EnhancedMemoryStore, None]:
     """Fill the index with 2 000 random embeddings to make the test realistic."""
     settings = UnifiedSettings.for_testing()
     store = EnhancedMemoryStore(settings)
+    await store.start()
     for _ in range(2_000):
         await store.add_memory(
             text="dummy",

--- a/tests/test_store_error_conditions.py
+++ b/tests/test_store_error_conditions.py
@@ -12,6 +12,7 @@ from memory_system.core.index import ANNIndexError
 async def test_add_memory_invalid_embedding_dimension() -> None:
     settings = UnifiedSettings.for_testing()
     store = EnhancedMemoryStore(settings)
+    await store.start()
     try:
         bad_embedding = [0.0] * (settings.model.vector_dim - 1)
         with pytest.raises(ANNIndexError):
@@ -34,6 +35,7 @@ async def test_add_memory_invalid_embedding_dimension() -> None:
 async def test_add_memory_non_numeric_embedding() -> None:
     settings = UnifiedSettings.for_testing()
     store = EnhancedMemoryStore(settings)
+    await store.start()
     try:
         bad_embedding = ["x"] * settings.model.vector_dim
         with pytest.raises(ValueError):
@@ -56,6 +58,7 @@ async def test_add_memory_non_numeric_embedding() -> None:
 async def test_add_memory_database_failure() -> None:
     settings = UnifiedSettings.for_testing()
     store = EnhancedMemoryStore(settings)
+    await store.start()
     try:
         vec = list(np.random.rand(settings.model.vector_dim).astype(np.float32))
         with patch.object(


### PR DESCRIPTION
## Summary
- defer EnhancedMemoryStore background task creation to new async `start()` method
- ensure FastAPI startup and dependencies run `start()` before using the store
- update tests and docs to explicitly start the store

## Testing
- `pre-commit run --files README.md memory_system/api/app.py memory_system/api/dependencies.py memory_system/api/routes/health.py memory_system/core/enhanced_store.py tests/test_benchmark_regression.py tests/test_core.py tests/test_db_invariants.py tests/test_encryption_at_rest.py tests/test_enhanced_store.py tests/test_enhanced_store_impl.py tests/test_hypothesis_vectors.py tests/test_integration.py tests/test_multi_modality.py tests/test_performance.py tests/test_precision_at_k.py tests/test_semantic_search_benchmark.py tests/test_store_error_conditions.py` *(failed: command not found)*
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_6897137f9af48325bd21c49bd83a2c94