### PR TITLE
Validate metadata and enforce limits

### DIFF
--- a/memory_system/api/app.py
+++ b/memory_system/api/app.py
@@ -14,7 +14,7 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any, AsyncIterator, cast
 
-from fastapi import FastAPI, Request, Response
+from fastapi import FastAPI, Request, Response, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.routing import APIRouter
 from starlette.middleware.base import RequestResponseEndpoint
@@ -64,13 +64,33 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["Memory"], prefix="/memory")
 
 
+def _validate_metadata(meta: Any) -> dict[str, Any]:
+    if meta is None:
+        return {}
+    if isinstance(meta, str):
+        try:
+            meta = json.loads(meta)
+        except json.JSONDecodeError as exc:
+            raise HTTPException(status_code=400, detail="Invalid metadata JSON") from exc
+    if not isinstance(meta, dict):
+        raise HTTPException(status_code=400, detail="Metadata must be an object")
+    try:
+        json.dumps(meta)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail="Metadata must be JSON serializable") from exc
+    return meta
+
+
 @router.post("/add", summary="Add memory", response_description="Memory UUID")
 async def add_memory(request: Request, body: dict[str, Any]) -> dict[str, str]:
     """Add a new piece of memory."""
     store = cast(MemoryStoreProtocol, get_memory_store(request))
     modality = body.get("modality", "text")
-    metadata = body.get("metadata", {})
+    metadata = _validate_metadata(body.get("metadata", {}))
     metadata.setdefault("modality", modality)
+    max_len = getattr(getattr(getattr(store, "settings", None), "security", None), "max_text_length", 10_000)
+    if len(body.get("text", "")) > max_len:
+        raise HTTPException(status_code=400, detail="text exceeds maximum length")
     mem = await add(body["text"], metadata=metadata, modality=modality, store=store)
     return {"id": mem.memory_id}
 
@@ -93,7 +113,7 @@ async def search_memory(
 ) -> Any:
     """Semantic search across stored memories."""
     store = cast(MemoryStoreProtocol, get_memory_store(request))
-    metadata_filter = json.loads(metadata) if metadata else None
+    metadata_filter = _validate_metadata(metadata) if metadata else None
     return await search(q, k=limit, metadata_filter=metadata_filter, modality=modality, store=store)
 
 
@@ -104,7 +124,13 @@ async def add_memories_batch(request: Request, body: list[dict[str, Any]]) -> di
     if isinstance(store, EnhancedMemoryStore):
         mems = await store.add_memories_batch(body)
         return {"ids": [m.id for m in mems]}
-    memories = [Memory.new(item["text"], metadata=item.get("metadata", {})) for item in body]
+    max_len = getattr(getattr(getattr(store, "settings", None), "security", None), "max_text_length", 10_000)
+    memories: list[Memory] = []
+    for item in body:
+        if len(item.get("text", "")) > max_len:
+            raise HTTPException(status_code=400, detail="text exceeds maximum length")
+        meta = _validate_metadata(item.get("metadata", {}))
+        memories.append(Memory.new(item["text"], metadata=meta))
     await store.add_many(memories)  # type: ignore[attr-defined]
     return {"ids": [m.id for m in memories]}
 
@@ -113,6 +139,7 @@ async def add_memories_batch(request: Request, body: list[dict[str, Any]]) -> di
 async def stream_memories(request: Request) -> dict[str, int]:
     """Stream newline-delimited JSON memories to the store."""
     store = cast(MemoryStoreProtocol, get_memory_store(request))
+    max_len = getattr(getattr(getattr(store, "settings", None), "security", None), "max_text_length", 10_000)
 
     async def _aiter() -> AsyncIterator[dict[str, Any]]:
         async for line in request.stream():
@@ -127,7 +154,10 @@ async def stream_memories(request: Request) -> dict[str, int]:
     batch: list[Memory] = []
     count = 0
     async for item in _aiter():
-        batch.append(Memory.new(item["text"], metadata=item.get("metadata", {})))
+        if len(item.get("text", "")) > max_len:
+            raise HTTPException(status_code=400, detail="text exceeds maximum length")
+        meta = _validate_metadata(item.get("metadata", {}))
+        batch.append(Memory.new(item["text"], metadata=meta))
         if len(batch) >= 100:
             await store.add_many(batch)  # type: ignore[attr-defined]
             count += len(batch)

--- a/memory_system/core/enhanced_store.py
+++ b/memory_system/core/enhanced_store.py
@@ -22,7 +22,7 @@ __all__ = ["EnhancedMemoryStore", "HealthComponent"]
 log = logging.getLogger(__name__)
 
 from memory_system.config.settings import UnifiedSettings
-from memory_system.core.index import FaissHNSWIndex, MultiModalFaissIndex
+from memory_system.core.index import ANNIndexError, FaissHNSWIndex, MultiModalFaissIndex
 from memory_system.core.store import Memory, SQLiteMemoryStore
 from memory_system.core.summarization import SummaryStrategy
 
@@ -252,6 +252,15 @@ class EnhancedMemoryStore:
         updated_at: float | None = None,
     ) -> Memory:
         """Add a memory entry to the database and index."""
+        if len(text) > self.settings.security.max_text_length:
+            raise ValueError("text exceeds maximum length")
+        expected_dim = self.settings.model.vector_dims.get(
+            modality, self.settings.model.vector_dim
+        )
+        if len(embedding) != expected_dim:
+            raise ANNIndexError(
+                f"dimension mismatch: expected {expected_dim}, got {len(embedding)}"
+            )
         ts = created_at if created_at is not None else time.time()
         text_to_store = text
         if self.settings.security.encrypt_at_rest:
@@ -279,15 +288,27 @@ class EnhancedMemoryStore:
         mems: list[Memory] = []
         for item in items:
             text = item["text"]
+            if len(text) > self.settings.security.max_text_length:
+                raise ValueError("text exceeds maximum length")
+            modality = item.get("modality", "text")
+            expected_dim = self.settings.model.vector_dims.get(
+                modality, self.settings.model.vector_dim
+            )
+            emb = item["embedding"]
+            if len(emb) != expected_dim:
+                raise ANNIndexError(
+                    f"dimension mismatch: expected {expected_dim}, got {len(emb)}"
+                )
             text_to_store = text
             if self.settings.security.encrypt_at_rest:
                 f = Fernet(self.settings.security.encryption_key.encode())
                 text_to_store = f.encrypt(text.encode()).decode()
-            modality = item.get("modality", "text")
             mem = Memory(
                 id=str(uuid.uuid4()),
                 text=text_to_store,
-                created_at=dt.datetime.fromtimestamp(item.get("created_at", time.time()), tz=dt.timezone.utc),
+                created_at=dt.datetime.fromtimestamp(
+                    item.get("created_at", time.time()), tz=dt.timezone.utc
+                ),
                 importance=item.get("importance", 0.0),
                 valence=item.get("valence", 0.0),
                 emotional_intensity=item.get("emotional_intensity", 0.0),
@@ -295,7 +316,7 @@ class EnhancedMemoryStore:
                 modality=modality,
             )
             mems.append(mem)
-            vec = np.asarray(item["embedding"], dtype=np.float32)
+            vec = np.asarray(emb, dtype=np.float32)
             self._index.add_vectors(modality, [mem.id], np.asarray([vec], dtype=np.float32))
         await self._store.add_many(mems)
         self._index.save(str(self.settings.database.vec_path))
@@ -322,11 +343,21 @@ class EnhancedMemoryStore:
         total = 0
         async for item in _aiter(iterator):
             text = item["text"]
+            if len(text) > self.settings.security.max_text_length:
+                raise ValueError("text exceeds maximum length")
+            modality = item.get("modality", "text")
+            expected_dim = self.settings.model.vector_dims.get(
+                modality, self.settings.model.vector_dim
+            )
+            emb = item["embedding"]
+            if len(emb) != expected_dim:
+                raise ANNIndexError(
+                    f"dimension mismatch: expected {expected_dim}, got {len(emb)}"
+                )
             text_to_store = text
             if self.settings.security.encrypt_at_rest:
                 f = Fernet(self.settings.security.encryption_key.encode())
                 text_to_store = f.encrypt(text.encode()).decode()
-            modality = item.get("modality", "text")
             mem = Memory(
                 id=str(uuid.uuid4()),
                 text=text_to_store,
@@ -337,7 +368,7 @@ class EnhancedMemoryStore:
                 metadata={"role": item.get("role"), "tags": item.get("tags", [])},
                 modality=modality,
             )
-            batch.append((modality, mem, np.asarray(item["embedding"], dtype=np.float32)))
+            batch.append((modality, mem, np.asarray(emb, dtype=np.float32)))
             if len(batch) >= batch_size:
                 await self._store.add_many([m for _, m, _ in batch])
                 for mod, m, vec in batch:

--- a/memory_system/core/store.py
+++ b/memory_system/core/store.py
@@ -98,6 +98,19 @@ if TYPE_CHECKING:  # pragma: no cover - optional FastAPI import for type hints
 
 logger = logging.getLogger(__name__)
 
+MAX_TEXT_LENGTH = 10_000
+
+
+def _safe_json(data: Dict[str, Any] | None) -> str:
+    if not data:
+        return "null"
+    try:
+        dumped = json.dumps(data)
+        json.loads(dumped)
+    except (TypeError, ValueError) as exc:
+        raise TypeError("metadata must be JSON serializable") from exc
+    return dumped
+
 ###############################################################################
 # Data model
 ###############################################################################
@@ -378,6 +391,8 @@ class SQLiteMemoryStore:
     async def add(self, mem: Memory) -> None:
         """Persist a new :class:`Memory` to the database."""
         await self.initialise()
+        if len(mem.text) > MAX_TEXT_LENGTH:
+            raise ValueError("text exceeds maximum length")
         conn = await self._acquire()
         try:
             await conn.execute(
@@ -393,8 +408,8 @@ class SQLiteMemoryStore:
                     mem.level,
                     mem.episode_id,
                     mem.modality,
-                    json.dumps(mem.connections) if mem.connections else "null",
-                    json.dumps(mem.metadata) if mem.metadata else "null",
+                    _safe_json(mem.connections),
+                    _safe_json(mem.metadata),
                 ),
             )
             await conn.commit()
@@ -427,6 +442,8 @@ class SQLiteMemoryStore:
             )
             batch: list[tuple[Any, ...]] = []
             for mem in memories:
+                if len(mem.text) > MAX_TEXT_LENGTH:
+                    raise ValueError("text exceeds maximum length")
                 batch.append(
                     (
                         mem.id,
@@ -438,8 +455,8 @@ class SQLiteMemoryStore:
                         mem.level,
                         mem.episode_id,
                         mem.modality,
-                        json.dumps(mem.connections) if mem.connections else "null",
-                        json.dumps(mem.metadata) if mem.metadata else "null",
+                        _safe_json(mem.connections),
+                        _safe_json(mem.metadata),
                     )
                 )
                 if len(batch) >= batch_size:
@@ -855,6 +872,8 @@ class SQLiteMemoryStore:
         conn = await self._acquire()
         try:
             if text is not None:
+                if len(text) > MAX_TEXT_LENGTH:
+                    raise ValueError("text exceeds maximum length")
                 await conn.execute(
                     "UPDATE memories SET text = ? WHERE id = ?",
                     (text, memory_id),
@@ -909,7 +928,7 @@ class SQLiteMemoryStore:
                 existing.update(metadata)
                 await conn.execute(
                     "UPDATE memories SET metadata = json(?) WHERE id = ?",
-                    (json.dumps(existing), memory_id),
+                    (_safe_json(existing), memory_id),
                 )
 
             await conn.commit()


### PR DESCRIPTION
## Summary
- enforce maximum text length and embedding dimension across memory APIs
- validate metadata as JSON before database or API operations
- ensure SQLite store safely serializes metadata

## Testing
- `pytest tests/test_store_ext.py::test_json_error_handling -q` *(fails: async def functions are not natively supported)*
- `pip install numpy httpx -q` *(fails: Could not find a version that satisfies the requirement numpy)*
- `pip install pytest-asyncio -q` *(fails: Could not find a version that satisfies the requirement pytest-asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_68971cbb57a88325b19b13bfc62f7985