### PR TITLE
feat: add memory dynamics module

### DIFF
--- a/memory_system/core/enhanced_store.py
+++ b/memory_system/core/enhanced_store.py
@@ -24,6 +24,7 @@ from memory_system.core.faiss_vector_store import FaissVectorStore
 from memory_system.core.interfaces import MetaStore, VectorStore
 from memory_system.core.store import Memory, SQLiteMemoryStore
 from memory_system.core.summarization import SummaryStrategy
+from memory_system.core.memory_dynamics import MemoryDynamics
 
 
 @dataclass
@@ -47,6 +48,9 @@ class EnhancedMemoryStore:
         dsn = settings.get_database_url()
         self.meta_store: MetaStore = SQLiteMemoryStore(dsn)
         self.vector_store: VectorStore = FaissVectorStore(settings)
+
+        # Helper for reinforcement/decay/score operations
+        self._dynamics = MemoryDynamics(self.meta_store)
 
         # Backwards-compat for legacy tests that access private fields:
         self._store = self.meta_store          # type: ignore[attr-defined]
@@ -210,6 +214,44 @@ class EnhancedMemoryStore:
         await asyncio.to_thread(self.vector_store.save, str(self.settings.database.vec_path))
         self._memory_count += 1
         return mem
+
+    # ---- Memory dynamics ---------------------------------------------------
+
+    async def reinforce(
+        self,
+        memory_id: str,
+        amount: float = 0.1,
+        *,
+        valence_delta: float | None = None,
+        intensity_delta: float | None = None,
+    ) -> Memory:
+        """Delegate reinforcement to :class:`MemoryDynamics`."""
+        return await self._dynamics.reinforce(
+            memory_id,
+            amount,
+            valence_delta=valence_delta,
+            intensity_delta=intensity_delta,
+        )
+
+    def score(self, memory: Memory) -> float:
+        """Return the time-decayed ranking score for ``memory``."""
+        return self._dynamics.score(memory)
+
+    @staticmethod
+    def decay(
+        *,
+        importance: float,
+        valence: float,
+        emotional_intensity: float,
+        age_days: float,
+    ) -> float:
+        """Expose :func:`MemoryDynamics.decay` for convenience."""
+        return MemoryDynamics.decay(
+            importance=importance,
+            valence=valence,
+            emotional_intensity=emotional_intensity,
+            age_days=age_days,
+        )
 
     async def add_memories_batch(self, items: Sequence[dict[str, Any]]) -> list[Memory]:
         """Add multiple memories with embeddings in one batch."""

--- a/memory_system/core/maintenance.py
+++ b/memory_system/core/maintenance.py
@@ -23,6 +23,7 @@ from memory_system.core.hierarchical_summarizer import HierarchicalSummarizer
 from memory_system.core.index import FaissHNSWIndex
 from memory_system.core.store import Memory, SQLiteMemoryStore
 from memory_system.core.summarization import STRATEGIES, SummaryStrategy
+from memory_system.core.memory_dynamics import MemoryDynamics
 
 # ----------------------------- small utils -----------------------------
 
@@ -202,20 +203,13 @@ def _decay_score(
     emotional_intensity: float,
     age_days: float,
 ) -> float:
-    """
-    Age-aware retention score (higher -> keep):
-
-        base = 0.4*importance + 0.3*emotional_intensity + 0.3*valence
-        score = base * exp(-age_days / 30)
-
-    Negative valence lowers the base score, increasing the chance of forgetting,
-    while positive valence boosts retention.  Tuned to decay over ~1 month while
-    preserving high-importance/intense items.
-    """
-    base = 0.4 * importance + 0.3 * emotional_intensity + 0.3 * valence
-    base = max(0.0, base)
-    decay = float(np.exp(-age_days / 30.0))
-    return base * decay
+    """Compatibility wrapper around :func:`MemoryDynamics.decay`."""
+    return MemoryDynamics.decay(
+        importance=importance,
+        valence=valence,
+        emotional_intensity=emotional_intensity,
+        age_days=age_days,
+    )
 
 
 async def forget_old_memories(

--- a/memory_system/core/memory_dynamics.py
+++ b/memory_system/core/memory_dynamics.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import datetime as dt
+import math
+from dataclasses import dataclass, field
+from typing import Any, Protocol, Sequence
+
+from memory_system.core.store import Memory
+from memory_system.unified_memory import ListBestWeights
+
+
+class SupportsDynamics(Protocol):
+    async def update(self, memory_id: str, **kwargs: Any) -> Memory: ...
+    async def upsert_scores(self, scores: Sequence[tuple[str, float]]) -> None: ...
+
+
+def _default_weights() -> ListBestWeights:
+    try:  # lazy import to avoid heavy deps at import time
+        from memory_system.config.settings import get_settings
+
+        cfg = get_settings()
+        return ListBestWeights(**cfg.ranking.model_dump())
+    except Exception:  # pragma: no cover - settings module optional
+        return ListBestWeights()
+
+
+@dataclass
+class MemoryDynamics:
+    """Utilities for memory reinforcement, decay and scoring."""
+
+    store: SupportsDynamics | None = None
+    weights: ListBestWeights = field(default_factory=_default_weights)
+
+    # ------------------------------------------------------------------
+    # Reinforcement
+    # ------------------------------------------------------------------
+
+    async def reinforce(
+        self,
+        memory_id: str,
+        amount: float = 0.1,
+        *,
+        valence_delta: float | None = None,
+        intensity_delta: float | None = None,
+    ) -> Memory:
+        """Reinforce *memory_id* by ``amount`` and update its score."""
+        if self.store is None:
+            raise RuntimeError("store is required for reinforcement")
+
+        meta = {
+            "last_accessed": dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc).isoformat()
+        }
+        updated = await self.store.update(
+            memory_id,
+            importance_delta=amount,
+            valence_delta=valence_delta,
+            emotional_intensity_delta=intensity_delta,
+            metadata=meta,
+        )
+        score = self.score(updated)
+        await self.store.upsert_scores([(memory_id, score)])
+        return updated
+
+    # ------------------------------------------------------------------
+    # Scoring helpers
+    # ------------------------------------------------------------------
+
+    def score(self, memory: Memory, *, now: dt.datetime | None = None) -> float:
+        """Return the time-decayed ranking score for *memory*."""
+        valence_weight = (
+            self.weights.valence_pos if memory.valence >= 0 else self.weights.valence_neg
+        )
+        base = (
+            self.weights.importance * memory.importance
+            + self.weights.emotional_intensity * memory.emotional_intensity
+            + valence_weight * memory.valence
+        )
+        last = self._last_accessed(memory)
+        if now is None:
+            now = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc)
+        age_days = max(0.0, (now - last).total_seconds() / 86_400.0)
+        return base * math.exp(-age_days / 30.0)
+
+    @staticmethod
+    def _last_accessed(memory: Memory) -> dt.datetime:
+        if memory.metadata:
+            ts = memory.metadata.get("last_accessed")
+            if isinstance(ts, str):
+                try:
+                    return dt.datetime.fromisoformat(ts)
+                except ValueError:
+                    pass
+        return memory.created_at
+
+    # ------------------------------------------------------------------
+    # Decay scoring used for forgetting
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def decay(
+        *,
+        importance: float,
+        valence: float,
+        emotional_intensity: float,
+        age_days: float,
+    ) -> float:
+        """Return an age-aware retention score (higher → keep)."""
+        base = 0.4 * importance + 0.3 * emotional_intensity + 0.3 * valence
+        base = max(0.0, base)
+        return base * math.exp(-age_days / 30.0)


### PR DESCRIPTION
## Summary
- add `MemoryDynamics` utility for reinforcement, decay scoring and ranking
- delegate enhanced store reinforcement/score/decay to `MemoryDynamics`
- route maintenance decay score through the new utility

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68972787c0c08325b037f7a6806df4bc