### PR TITLE
Align API schemas with core signatures

### DIFF
--- a/memory_system/api/routes/memory.py
+++ b/memory_system/api/routes/memory.py
@@ -9,7 +9,6 @@ from typing import Any, Optional, cast
 
 from fastapi import APIRouter, HTTPException, Query, Request, status
 
-from memory_system import unified_memory
 from memory_system.api.schemas import (
     MemoryCreate,
     MemoryQuery,
@@ -18,7 +17,12 @@ from memory_system.api.schemas import (
     MemoryUpdate,
 )
 from memory_system.core.store import Memory, SQLiteMemoryStore, get_memory_store, get_store
-from memory_system.unified_memory import ListBestWeights
+from memory_system.unified_memory import (
+    ListBestWeights,
+    list_best,
+    reinforce,
+    update,
+)
 from memory_system.utils.security import EnhancedPIIFilter
 
 log = logging.getLogger(__name__)
@@ -99,7 +103,7 @@ async def update_memory(memory_id: str, payload: MemoryUpdate, request: Request)
         metadata["role"] = payload.role
     if payload.tags is not None:
         metadata["tags"] = payload.tags
-    updated = await unified_memory.update(
+    updated = await update(
         memory_id,
         text=payload.text,
         metadata=metadata or None,
@@ -107,8 +111,8 @@ async def update_memory(memory_id: str, payload: MemoryUpdate, request: Request)
         importance_delta=payload.importance_delta,
         valence=payload.valence,
         valence_delta=payload.valence_delta,
-        emotional_intensity=payload.arousal,
-        emotional_intensity_delta=payload.arousal_delta,
+        emotional_intensity=payload.emotional_intensity,
+        emotional_intensity_delta=payload.emotional_intensity_delta,
         store=store,
     )
     mem_read = MemoryRead.model_validate(asdict(updated))
@@ -119,11 +123,11 @@ async def update_memory(memory_id: str, payload: MemoryUpdate, request: Request)
 async def reinforce_memory(memory_id: str, payload: MemoryReinforce, request: Request) -> MemoryRead:
     """Reinforce a memory's scoring attributes."""
     store = await _store(request)
-    updated = await unified_memory.reinforce(
+    updated = await reinforce(
         memory_id,
         amount=payload.importance_delta,
         valence_delta=payload.valence_delta,
-        intensity_delta=payload.arousal_delta,
+        intensity_delta=payload.emotional_intensity_delta,
         store=store,
     )
     mem_read = MemoryRead.model_validate(asdict(updated))
@@ -137,9 +141,12 @@ async def best_memories(
     level: int | None = Query(None, ge=0),
     user_id: str | None = Query(None),
     importance: Optional[float] = Query(None, ge=0.0, description="Weight for importance when ranking"),
-    arousal: Optional[float] = Query(
-        None, ge=0.0, description="Weight for emotional intensity (arousal)"
-    ),  # alias для emotional_intensity
+    emotional_intensity: Optional[float] = Query(
+        None,
+        ge=0.0,
+        alias="arousal",
+        description="Weight for emotional intensity (arousal)",
+    ),
     valence_pos: Optional[float] = Query(None, ge=0.0, description="Weight for positive valence"),
     valence_neg: Optional[float] = Query(None, ge=0.0, description="Weight for negative valence"),
 ):
@@ -147,15 +154,15 @@ async def best_memories(
     meta = {"user_id": user_id} if user_id else None
 
     weights = None
-    if any(v is not None for v in (importance, arousal, valence_pos, valence_neg)):
+    if any(v is not None for v in (importance, emotional_intensity, valence_pos, valence_neg)):
         weights = ListBestWeights(
             importance=importance or 1.0,
-            emotional_intensity=arousal or 1.0,
+            emotional_intensity=emotional_intensity or 1.0,
             valence_pos=valence_pos or 1.0,
             valence_neg=valence_neg or 0.5,
         )
 
-    records = await unified_memory.list_best(
+    records = await list_best(
         n=n,
         store=store,
         level=level,

--- a/memory_system/api/schemas.py
+++ b/memory_system/api/schemas.py
@@ -29,12 +29,13 @@ class MemoryBase(BaseModel):
     role: str = Field("user", max_length=32, description="Conversation role label")
     tags: list[str] = Field(default_factory=list, max_length=10)
     valence: float = Field(0.0, ge=-1.0, le=1.0, description="Emotion polarity")
-    arousal: float = Field(
+    emotional_intensity: float = Field(
         0.0,
         ge=0.0,
         le=1.0,
         description="Strength of emotional reaction",
         validation_alias=AliasChoices("arousal", "emotional_intensity"),
+        serialization_alias="arousal",
     )
     importance: float = Field(
         0.0,
@@ -55,8 +56,8 @@ class MemoryBase(BaseModel):
             raise ValueError("too many tags")
         if not -1.0 <= self.valence <= 1.0:
             raise ValueError("valence must be between -1 and 1")
-        if not 0.0 <= self.arousal <= 1.0:
-            raise ValueError("arousal must be between 0 and 1")
+        if not 0.0 <= self.emotional_intensity <= 1.0:
+            raise ValueError("emotional_intensity must be between 0 and 1")
         if not 0.0 <= self.importance <= 1.0:
             raise ValueError("importance must be between 0 and 1")
 
@@ -73,8 +74,9 @@ class MemoryCreate(MemoryBase):
 class MemoryUpdate(BaseModel):
     """Payload for partial updates where all fields are optional.
 
-    ``valence``, ``arousal`` and ``importance`` replace the existing values
-    directly, whereas the ``*_delta`` counterparts add to the current value.
+    ``valence``, ``emotional_intensity`` and ``importance`` replace the
+    existing values directly, whereas the ``*_delta`` counterparts add to the
+    current value.
     """
 
     text: str | None = Field(default=None, min_length=1, max_length=10_000)
@@ -86,11 +88,12 @@ class MemoryUpdate(BaseModel):
         le=1.0,
         description="Set absolute valence value",
     )
-    arousal: float | None = Field(
+    emotional_intensity: float | None = Field(
         default=None,
         ge=0.0,
         le=1.0,
         validation_alias=AliasChoices("arousal", "emotional_intensity"),
+        serialization_alias="arousal",
         description="Set absolute arousal/emotional intensity",
     )
     importance: float | None = Field(
@@ -103,9 +106,10 @@ class MemoryUpdate(BaseModel):
         default=None,
         description="Increment to apply to current valence",
     )
-    arousal_delta: float | None = Field(
+    emotional_intensity_delta: float | None = Field(
         default=None,
         validation_alias=AliasChoices("arousal_delta", "emotional_intensity_delta"),
+        serialization_alias="arousal_delta",
         description="Increment to apply to current arousal",
     )
     importance_delta: float | None = Field(
@@ -124,9 +128,10 @@ class MemoryReinforce(BaseModel):
 
     importance_delta: float = Field(0.1)
     valence_delta: float | None = Field(default=None)
-    arousal_delta: float | None = Field(
+    emotional_intensity_delta: float | None = Field(
         default=None,
         validation_alias=AliasChoices("arousal_delta", "emotional_intensity_delta"),
+        serialization_alias="arousal_delta",
     )
 
     model_config = {
@@ -143,11 +148,12 @@ class MemoryRead(MemoryBase):
     created_at: datetime
     updated_at: datetime | None = None
     valence: float = Field(0.0, ge=-1.0, le=1.0)
-    arousal: float = Field(
+    emotional_intensity: float = Field(
         0.0,
         ge=0.0,
         le=1.0,
         validation_alias=AliasChoices("arousal", "emotional_intensity"),
+        serialization_alias="arousal",
     )
     importance: float = Field(0.0, ge=0.0, le=1.0)
 


### PR DESCRIPTION
## Summary
- rename API schema fields to match core's `emotional_intensity` nomenclature while keeping `arousal` aliases
- import core helpers directly in memory routes and align `/best` weight and `/update` parameters

## Testing
- `ruff check memory_system/api/routes/memory.py memory_system/api/schemas.py`
- `mypy memory_system/api/routes/memory.py memory_system/api/schemas.py` *(fails: many missing/invalid types across project)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68972b780d9c832594450f6e3c5226ae