### PR TITLE
chore: address ruff lint warnings

### DIFF
--- a/memory_system/api/app.py
+++ b/memory_system/api/app.py
@@ -14,11 +14,21 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any, AsyncIterator, cast
 
-from fastapi import FastAPI, Request, Response, HTTPException
+from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.routing import APIRouter
 from starlette.middleware.base import RequestResponseEndpoint
 from starlette.requests import Request as StarletteRequest
+
+from memory_system import __version__
+from memory_system.api.middleware import MaintenanceModeMiddleware, RateLimitingMiddleware
+from memory_system.api.routes import admin as admin_routes
+from memory_system.api.routes import health as health_routes
+from memory_system.api.routes import memory as memory_routes
+from memory_system.config.settings import UnifiedSettings, configure_logging, get_settings
+from memory_system.core.enhanced_store import EnhancedMemoryStore
+from memory_system.core.store import Memory, get_memory_store
+from memory_system.memory_helpers import MemoryStoreProtocol, add, delete, search
 
 if TYPE_CHECKING:  # Only for type checking, not at runtime
     from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
@@ -41,20 +51,6 @@ if not hasattr(StarletteRequest, "_ums_app_setter"):
 
     StarletteRequest.app = property(lambda self: self.scope.get("app"), _set_app)
     StarletteRequest._ums_app_setter = True
-
-from memory_system import __version__
-from memory_system.api.middleware import MaintenanceModeMiddleware, RateLimitingMiddleware
-from memory_system.api.routes import admin as admin_routes
-from memory_system.api.routes import health as health_routes
-from memory_system.api.routes import memory as memory_routes
-from memory_system.config.settings import (
-    UnifiedSettings,
-    configure_logging,
-    get_settings,
-)
-from memory_system.core.enhanced_store import EnhancedMemoryStore
-from memory_system.core.store import Memory, get_memory_store
-from memory_system.memory_helpers import MemoryStoreProtocol, add, delete, search
 
 logger = logging.getLogger(__name__)
 

--- a/memory_system/core/enhanced_store.py
+++ b/memory_system/core/enhanced_store.py
@@ -10,21 +10,21 @@ import time
 import uuid
 from contextlib import suppress
 from dataclasses import dataclass
-from typing import Any, AsyncIterator, Iterable, Sequence, MutableMapping, cast
+from typing import Any, AsyncIterator, Iterable, MutableMapping, Sequence, cast
 
 import numpy as np
 from cryptography.fernet import Fernet
 
-__all__ = ["EnhancedMemoryStore", "HealthComponent"]
-
-log = logging.getLogger(__name__)
-
 from memory_system.config.settings import UnifiedSettings
 from memory_system.core.faiss_vector_store import FaissVectorStore
 from memory_system.core.interfaces import MetaStore, VectorStore
+from memory_system.core.memory_dynamics import MemoryDynamics
 from memory_system.core.store import Memory, SQLiteMemoryStore
 from memory_system.core.summarization import SummaryStrategy
-from memory_system.core.memory_dynamics import MemoryDynamics
+
+__all__ = ["EnhancedMemoryStore", "HealthComponent"]
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -61,7 +61,7 @@ class EnhancedMemoryStore:
         self._dynamics = MemoryDynamics(self.meta_store)
 
         # Backwards-compat for legacy tests that access private fields:
-        self._store = self.meta_store          # type: ignore[attr-defined]
+        self._store = self.meta_store  # type: ignore[attr-defined]
         self._index = getattr(self.vector_store, "index", None)  # type: ignore[attr-defined]
 
         vec_path = settings.database.vec_path
@@ -389,10 +389,8 @@ class EnhancedMemoryStore:
         """
         # ANN search with over-sampling to improve recall
         vec = np.asarray(vector, dtype=np.float32)
-        ids, dists = self.vector_store.search(
-            vec, k=max(k * 5, k), modality=modality, ef_search=ef_search
-        )
-        candidates = list(zip(ids, dists))
+        ids, dists = self.vector_store.search(vec, k=max(k * 5, k), modality=modality, ef_search=ef_search)
+        candidates = list(zip(ids, dists, strict=True))
 
         # Filter by metadata and/or level via the meta store
         md = dict(metadata_filter or {})

--- a/memory_system/core/maintenance.py
+++ b/memory_system/core/maintenance.py
@@ -21,9 +21,9 @@ import numpy as np
 from embedder import embed as embed_text
 from memory_system.core.hierarchical_summarizer import HierarchicalSummarizer
 from memory_system.core.index import FaissHNSWIndex
+from memory_system.core.memory_dynamics import MemoryDynamics
 from memory_system.core.store import Memory, SQLiteMemoryStore
 from memory_system.core.summarization import STRATEGIES, SummaryStrategy
-from memory_system.core.memory_dynamics import MemoryDynamics
 
 # ----------------------------- small utils -----------------------------
 

--- a/memory_system/core/memory_dynamics.py
+++ b/memory_system/core/memory_dynamics.py
@@ -47,9 +47,7 @@ class MemoryDynamics:
         if self.store is None:
             raise RuntimeError("store is required for reinforcement")
 
-        meta = {
-            "last_accessed": dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc).isoformat()
-        }
+        meta = {"last_accessed": dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc).isoformat()}
         updated = await self.store.update(
             memory_id,
             importance_delta=amount,
@@ -67,9 +65,7 @@ class MemoryDynamics:
 
     def score(self, memory: Memory, *, now: dt.datetime | None = None) -> float:
         """Return the time-decayed ranking score for *memory*."""
-        valence_weight = (
-            self.weights.valence_pos if memory.valence >= 0 else self.weights.valence_neg
-        )
+        valence_weight = self.weights.valence_pos if memory.valence >= 0 else self.weights.valence_neg
         base = (
             self.weights.importance * memory.importance
             + self.weights.emotional_intensity * memory.emotional_intensity

--- a/memory_system/core/store.py
+++ b/memory_system/core/store.py
@@ -111,6 +111,7 @@ def _safe_json(data: Dict[str, Any] | None) -> str:
         raise TypeError("metadata must be JSON serializable") from exc
     return dumped
 
+
 ###############################################################################
 # Data model
 ###############################################################################


### PR DESCRIPTION
## Summary
- organize imports across API and core modules
- add explicit `strict` argument when zipping search results
- format supporting modules to satisfy `ruff format`

## Testing
- `ruff check .`
- `pytest` *(fails: Interrupted: 31 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68972f2426a88325b7bd237dad8bc15c