### PR TITLE
Apply intensity decay to memory scoring

### DIFF
--- a/memory_system/core/memory_dynamics.py
+++ b/memory_system/core/memory_dynamics.py
@@ -78,17 +78,18 @@ class MemoryDynamics:
     # ------------------------------------------------------------------
 
     def score(self, memory: Memory, *, now: dt.datetime | None = None) -> float:
-        """Return the time-decayed ranking score for *memory*."""
+        """Return the ranking score for *memory* with intensity decay."""
         valence_weight = self.weights.valence_pos if memory.valence >= 0 else self.weights.valence_neg
         imp = max(0.0, min(1.0, memory.importance))
         inten = max(0.0, min(1.0, memory.emotional_intensity))
         val = max(-1.0, min(1.0, memory.valence))
-        base = self.weights.importance * imp + self.weights.emotional_intensity * inten + valence_weight * val
         last = self._last_accessed(memory)
         if now is None:
             now = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc)
         age_days = max(0.0, (now - last).total_seconds() / 86_400.0)
-        return base * math.exp(-age_days / _decay_rate())
+        decay = math.exp(-age_days / _decay_rate())
+        inten *= decay
+        return self.weights.importance * imp + self.weights.emotional_intensity * inten + valence_weight * val
 
     @staticmethod
     def _last_accessed(memory: Memory) -> dt.datetime:

--- a/memory_system/unified_memory.py
+++ b/memory_system/unified_memory.py
@@ -529,21 +529,19 @@ def _last_accessed(m: Memory) -> _dt.datetime:
 
 
 def _score_decay(m: Memory, weights: ListBestWeights) -> float:
-    """Return a time-decayed ranking score for *m*.
+    """Return a ranking score for *m* with intensity decay."""
 
-    The base score is derived from :func:`_score_best` and is exponentially
-    decayed over roughly one month based on the elapsed time since
-    ``last_accessed``.
-    """
-
-    base = _score_best(m, weights)
     last = _last_accessed(m)
-    age_days = max(
-        0.0,
-        (_dt.datetime.utcnow().replace(tzinfo=_dt.timezone.utc) - last).total_seconds() / 86_400.0,
-    )
+    now = _dt.datetime.utcnow().replace(tzinfo=_dt.timezone.utc)
+    age_days = max(0.0, (now - last).total_seconds() / 86_400.0)
     rate = max(_get_dynamics().decay_rate, 1e-9)
-    return base * math.exp(-age_days / rate)
+    decayed_intensity = m.emotional_intensity * math.exp(-age_days / rate)
+    valence_weight = weights.valence_pos if m.valence >= 0 else weights.valence_neg
+    return (
+        weights.importance * m.importance
+        + weights.emotional_intensity * decayed_intensity
+        + valence_weight * m.valence
+    )
 
 
 def _ensure_memory(m: Any) -> Memory:

--- a/tests/test_intensity_decay.py
+++ b/tests/test_intensity_decay.py
@@ -1,0 +1,25 @@
+import datetime as dt
+import math
+
+import pytest
+
+from memory_system.core.memory_dynamics import MemoryDynamics
+from memory_system.core.store import Memory
+
+
+def test_intensity_decay() -> None:
+    now = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc)
+    past = now - dt.timedelta(days=10)
+    mem = Memory(
+        id="1",
+        text="t",
+        created_at=now,
+        importance=0.0,
+        valence=0.0,
+        emotional_intensity=1.0,
+        metadata={"last_accessed": past.isoformat()},
+    )
+    dyn = MemoryDynamics()
+    score = dyn.score(mem, now=now)
+    expected = math.exp(-10 / 30.0)
+    assert score == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- apply exponential decay to emotional intensity in ranking calculations
- add unit test verifying intensity decay behaviour

## Testing
- `pre-commit run --files memory_system/core/memory_dynamics.py memory_system/unified_memory.py` *(failed: command not found)*
- `pip install pre-commit` *(failed: Could not find a version...)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'httpx', etc.)*
- `pytest tests/test_intensity_decay.py`

------
https://chatgpt.com/codex/tasks/task_e_68974307795c8325adebf1038b7099d5