### PR TITLE
feat: filter search results by minimum score

### DIFF
--- a/memory_system/config/settings.py
+++ b/memory_system/config/settings.py
@@ -245,6 +245,7 @@ class RankingConfig(BaseModel):
     emotional_intensity: float = 1.0
     valence_pos: float = 1.0
     valence_neg: float = 0.5
+    min_score: float = Field(0.0, ge=0.0, description="Minimum combined ranking score for search results")
 
     model_config = {"frozen": True}
 

--- a/memory_system/core/enhanced_store.py
+++ b/memory_system/core/enhanced_store.py
@@ -505,12 +505,14 @@ class EnhancedMemoryStore:
         md = dict(metadata_filter or {})
         md.setdefault("modality", modality)
         weights = _get_ranking_weights()
+        min_score = getattr(self.settings.ranking, "min_score", 0.0)
         allowed = await self.meta_store.top_n_by_score(
             k,
             level=level,
             metadata_filter=md,
             weights=weights,
             ids=list(ids),
+            min_score=min_score,
         )
         if return_distance:
             dist_map = dict(zip(ids, dists, strict=True))

--- a/memory_system/core/store.py
+++ b/memory_system/core/store.py
@@ -778,6 +778,7 @@ class SQLiteMemoryStore:
         metadata_filter: MutableMapping[str, Any] | None = None,
         weights: ListBestWeights | None = None,
         ids: Sequence[str] | None = None,
+        min_score: float | None = None,
     ) -> List[Memory]:
         """Return ``n`` memories ordered by ranking score.
 
@@ -818,6 +819,9 @@ class SQLiteMemoryStore:
                     placeholders = ", ".join(["?"] * len(ids))
                     clauses.append(f"m.id IN ({placeholders})")
                     params.extend(ids)
+                if min_score is not None:
+                    clauses.append("s.score >= ?")
+                    params.append(min_score)
                 sql = (
                     "SELECT m.id, m.text, m.created_at, m.importance, m.valence, "
                     "m.emotional_intensity, m.level, m.episode_id, m.modality, m.connections, m.metadata "
@@ -834,6 +838,7 @@ class SQLiteMemoryStore:
                     level=level,
                     metadata_filter=metadata_filter,
                     ids=ids,
+                    min_score=min_score,
                 )
             cursor = await conn.execute(sql, params)
             rows = await cursor.fetchall()

--- a/memory_system/core/top_n_by_score_sql.py
+++ b/memory_system/core/top_n_by_score_sql.py
@@ -14,6 +14,7 @@ def build_top_n_by_score_sql(
     level: int | None = None,
     metadata_filter: MutableMapping[str, Any] | None = None,
     ids: Sequence[str] | None = None,
+    min_score: float | None = None,
 ) -> tuple[str, Sequence[Any]]:
     """Return SQL and params to fetch *n* memories ranked by weighted score."""
     clauses: list[str] = []
@@ -33,6 +34,10 @@ def build_top_n_by_score_sql(
         placeholders = ", ".join(["?"] * len(ids))
         clauses.append(f"m.id IN ({placeholders})")
         params.extend(ids)
+    score_expr = (
+        "(m.importance * ?) + (m.emotional_intensity * ?) + "
+        "(CASE WHEN m.valence >= 0 THEN m.valence * ? ELSE m.valence * ? END)"
+    )
     sql = (
         "SELECT m.id, m.text, m.created_at, m.importance, m.valence, "
         "m.emotional_intensity, m.level, m.episode_id, m.modality, m.connections, m.metadata "
@@ -40,11 +45,19 @@ def build_top_n_by_score_sql(
     )
     if clauses:
         sql += " WHERE " + " AND ".join(clauses)
-    sql += (
-        " ORDER BY (m.importance * ?) + (m.emotional_intensity * ?) + "
-        "(CASE WHEN m.valence >= 0 THEN m.valence * ? ELSE m.valence * ? END) "
-        "DESC LIMIT ?"
-    )
+    if min_score is not None:
+        cond = f"{score_expr} >= ?"
+        sql += (" AND " if clauses else " WHERE ") + cond
+        params.extend(
+            [
+                weights.importance,
+                weights.emotional_intensity,
+                weights.valence_pos,
+                weights.valence_neg,
+                min_score,
+            ]
+        )
+    sql += f" ORDER BY {score_expr} DESC LIMIT ?"
     params.extend(
         [
             weights.importance,

--- a/memory_system/unified_memory.py
+++ b/memory_system/unified_memory.py
@@ -491,7 +491,7 @@ def _get_ranking_weights() -> ListBestWeights:
         from memory_system.config.settings import get_settings
 
         cfg = get_settings()
-        return ListBestWeights(**cfg.ranking.model_dump())
+        return ListBestWeights(**cfg.ranking.model_dump(exclude={"min_score"}))
     except Exception:  # pragma: no cover - settings module optional
         return ListBestWeights()
 

--- a/tests/test_enhanced_store.py
+++ b/tests/test_enhanced_store.py
@@ -15,11 +15,11 @@ import numpy as np
 import pytest
 import pytest_asyncio
 
-from memory_system.config.settings import UnifiedSettings
+from memory_system.config.settings import RankingConfig, UnifiedSettings
 from memory_system.core.enhanced_store import EnhancedMemoryStore
 from memory_system.core.index import ANNIndexError
-from memory_system.unified_memory import _get_ranking_weights
 from memory_system.core.store import Memory
+from memory_system.unified_memory import _get_ranking_weights
 
 
 @pytest_asyncio.fixture(scope="function")
@@ -187,3 +187,41 @@ async def test_duplicate_embeddings_rejected(store: EnhancedMemoryStore) -> None
     # we check duplicate detection at the index level
     with pytest.raises(ValueError):
         store._index.add_vectors([store._index._id_map[1]], np.asarray([v1], dtype=np.float32))
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_respects_min_score() -> None:
+    settings = UnifiedSettings.for_testing()
+    settings = settings.model_copy(update={"ranking": RankingConfig(min_score=0.5)})
+    store = EnhancedMemoryStore(settings)
+    await store.start()
+    try:
+        dim = store.settings.model.vector_dim
+        embedding = _rand_embedding(dim)
+        now = time.time()
+
+        await store.add_memory(
+            text="high",
+            importance=0.8,
+            embedding=embedding,
+            created_at=now,
+            updated_at=now,
+            valence=0.0,
+            emotional_intensity=0.0,
+        )
+        await store.add_memory(
+            text="low",
+            importance=0.1,
+            embedding=embedding,
+            created_at=now,
+            updated_at=now,
+            valence=0.0,
+            emotional_intensity=0.0,
+        )
+
+        res = await store.semantic_search(vector=embedding, k=5)
+        texts = [m.text for m in res]
+        assert "high" in texts
+        assert "low" not in texts
+    finally:
+        await store.close()


### PR DESCRIPTION
## Summary
- allow configuring a minimum combined ranking score for search results
- filter results below this threshold during semantic search
- add regression test for min_score filtering

## Testing
- `pytest tests/test_enhanced_store.py::test_semantic_search_respects_min_score -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install -q numpy==1.26.4 faiss-cpu==1.7.4` *(fails: Could not find a version that satisfies the requirement numpy==1.26.4)*


------
https://chatgpt.com/codex/tasks/task_e_6897430a74748325b0d29530b5948f99