### PR TITLE
feat: index episode and modality fields

### DIFF
--- a/memory_system/core/store.py
+++ b/memory_system/core/store.py
@@ -380,8 +380,18 @@ class SQLiteMemoryStore:
                 if mem_count != fts_count:
                     await conn.execute("DELETE FROM memories_fts")
                     await conn.execute("INSERT INTO memories_fts(rowid, text) SELECT rowid, text FROM memories")
-                await conn.execute("CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories(created_at)")
-                await conn.execute("CREATE INDEX IF NOT EXISTS idx_memories_level ON memories(level)")
+                await conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories(created_at)"
+                )
+                await conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_memories_level ON memories(level)"
+                )
+                await conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_memories_episode_id ON memories(episode_id)"
+                )
+                await conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_memories_modality ON memories(modality)"
+                )
                 await conn.commit()
                 self._initialised = True
             finally:
@@ -719,22 +729,39 @@ class SQLiteMemoryStore:
         finally:
             await self._release(conn)
 
-    async def list_recent(self, *, n: int = 20, level: int | None = None) -> List[Memory]:
-        """Return the most recent *n* memories, optionally filtered by level."""
+    async def list_recent(
+        self,
+        *,
+        n: int = 20,
+        level: int | None = None,
+        metadata_filter: MutableMapping[str, Any] | None = None,
+    ) -> List[Memory]:
+        """Return the most recent *n* memories with optional filters."""
+
         await self.initialise()
         conn = await self._acquire()
         try:
-            params: tuple[Any, ...]
+            clauses: list[str] = []
+            params: list[Any] = []
+            if level is not None:
+                clauses.append("level = ?")
+                params.append(level)
+            if metadata_filter:
+                for key, val in metadata_filter.items():
+                    if key in {"episode_id", "modality"}:
+                        clauses.append(f"{key} = ?")
+                        params.append(val)
+                    else:
+                        clauses.append("json_extract(metadata, ?) = ?")
+                        params.extend([f"$.{key}", val])
             sql = (
                 "SELECT id, text, created_at, importance, valence, emotional_intensity, level, "
                 "episode_id, modality, connections, metadata FROM memories"
             )
-            if level is not None:
-                sql += " WHERE level = ? ORDER BY created_at DESC LIMIT ?"
-                params = (level, n)
-            else:
-                sql += " ORDER BY created_at DESC LIMIT ?"
-                params = (n,)
+            if clauses:
+                sql += " WHERE " + " AND ".join(clauses)
+            sql += " ORDER BY created_at DESC LIMIT ?"
+            params.append(n)
             cursor = await conn.execute(sql, params)
             rows = await cursor.fetchall()
             return [self._row_to_memory(r) for r in rows]

--- a/memory_system/unified_memory.py
+++ b/memory_system/unified_memory.py
@@ -448,12 +448,16 @@ async def reinforce(
 async def list_recent(
     n: int = 20,
     *,
+    level: int | None = None,
+    metadata_filter: MutableMapping[str, Any] | None = None,
     store: MemoryStoreProtocol | None = None,
 ) -> Sequence[Memory]:
     """Return *n* most recently added memories in descending chronological order.
 
     Args:
         n (int, optional): Number of memories. Defaults to 20.
+        level (int | None, optional): Exact level filter. Defaults to None.
+        metadata_filter (MutableMapping[str, Any] | None, optional): Additional metadata filters.
         store (MemoryStoreProtocol | None, optional): Store object. Defaults to None.
 
     Returns:
@@ -461,7 +465,10 @@ async def list_recent(
     """
     st = await _resolve_store(store)
     try:
-        recent = await asyncio.wait_for(st.list_recent(n=n), timeout=ASYNC_TIMEOUT)
+        recent = await asyncio.wait_for(
+            st.list_recent(n=n, level=level, metadata_filter=metadata_filter),
+            timeout=ASYNC_TIMEOUT,
+        )
         logger.debug("Fetched %d recent memories.", len(recent))
     except Exception as e:
         logger.error("List recent failed: %s", e)

--- a/tests/test_store_ext.py
+++ b/tests/test_store_ext.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import aiosqlite
 
 from memory_system.core.store import Memory, SQLiteMemoryStore, get_store
 from memory_system.unified_memory import add as um_add
@@ -321,5 +322,39 @@ def test_unified_update_sets_emotions(store: SQLiteMemoryStore) -> None:
         )
         assert updated.valence == pytest.approx(-0.5)
         assert updated.emotional_intensity == pytest.approx(0.9)
+
+    asyncio.run(_run())
+
+
+def test_list_recent_metadata_filter(store: SQLiteMemoryStore) -> None:
+    async def _run() -> None:
+        m1 = Memory.new("one", episode_id="ep1", modality="text")
+        m2 = Memory.new("two", episode_id="ep2", modality="image")
+        await store.add(m1)
+        await store.add(m2)
+
+        res_ep1 = await store.list_recent(metadata_filter={"episode_id": "ep1"})
+        assert [m.id for m in res_ep1] == [m1.id]
+
+        res_mod = await store.list_recent(metadata_filter={"modality": "image"})
+        assert [m.id for m in res_mod] == [m2.id]
+
+    asyncio.run(_run())
+
+
+def test_schema_has_episode_modality_indexes(store: SQLiteMemoryStore) -> None:
+    async def _run() -> None:
+        await store.initialise()
+        conn = await aiosqlite.connect(store._path.as_posix())  # type: ignore[attr-defined]
+        try:
+            cur = await conn.execute("PRAGMA table_info(memories)")
+            cols = {row[1] for row in await cur.fetchall()}
+            assert {"episode_id", "modality"}.issubset(cols)
+            cur = await conn.execute("PRAGMA index_list(memories)")
+            idx = {row[1] for row in await cur.fetchall()}
+            assert "idx_memories_episode_id" in idx
+            assert "idx_memories_modality" in idx
+        finally:
+            await conn.close()
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- index episode_id and modality columns in SQLiteMemoryStore
- allow list_recent to filter by episode_id, modality, and metadata
- expose new filtering through unified_memory
- test schema indexes and filtering

## Testing
- `pytest tests/test_store_ext.py::test_list_recent_metadata_filter tests/test_store_ext.py::test_schema_has_episode_modality_indexes`
- `pytest` *(fails: 32 errors during collection)*
- `pre-commit run --files memory_system/core/store.py memory_system/unified_memory.py tests/test_store_ext.py` *(fails: command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68974553905883259126183d712189d1