### PR TITLE
feat: expose score breakdown in dev mode

### DIFF
--- a/memory_system/api/routes/memory.py
+++ b/memory_system/api/routes/memory.py
@@ -23,6 +23,7 @@ from memory_system.unified_memory import (
     reinforce,
     update,
 )
+from memory_system.core.memory_dynamics import MemoryDynamics
 from memory_system.utils.security import EnhancedPIIFilter
 
 log = logging.getLogger(__name__)
@@ -149,6 +150,10 @@ async def best_memories(
     ),
     valence_pos: Optional[float] = Query(None, ge=0.0, description="Weight for positive valence"),
     valence_neg: Optional[float] = Query(None, ge=0.0, description="Weight for negative valence"),
+    score_parts: bool = Query(
+        False,
+        description="Include score component breakdown (dev only)",
+    ),
 ):
     store = await _store(request)
     meta = {"user_id": user_id} if user_id else None
@@ -169,5 +174,24 @@ async def best_memories(
         metadata_filter=meta,
         weights=weights,
     )
-    payload = [MemoryRead.model_validate(asdict(r)) for r in records]
+
+    include_parts = False
+    if score_parts:
+        try:
+            from memory_system.config.settings import get_settings
+
+            include_parts = get_settings().profile == "development"
+        except Exception:  # pragma: no cover - settings optional
+            include_parts = False
+
+    dyn = MemoryDynamics(weights=weights) if include_parts else None
+    payload: list[dict[str, Any]] = []
+    for r in records:
+        data = asdict(r)
+        if include_parts and dyn is not None:
+            score, parts = dyn.score(r, return_parts=True)
+            parts["total"] = score
+            data["score_parts"] = parts
+        model = MemoryRead.model_validate(data)
+        payload.append(model.model_dump(exclude_none=True))
     return payload

--- a/memory_system/api/schemas.py
+++ b/memory_system/api/schemas.py
@@ -177,6 +177,10 @@ class MemoryRead(MemoryBase):
         serialization_alias="arousal",
     )
     importance: float = Field(0.0, ge=0.0, le=1.0)
+    score_parts: dict[str, float] | None = Field(
+        default=None,
+        description="Optional weighted score components",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/memory_system/core/memory_dynamics.py
+++ b/memory_system/core/memory_dynamics.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import datetime as dt
+import logging
 import math
 from dataclasses import dataclass, field
 from typing import Any, Protocol, Sequence
 
 from memory_system.core.store import Memory
 from memory_system.unified_memory import ListBestWeights
+
+log = logging.getLogger(__name__)
 
 
 class SupportsDynamics(Protocol):
@@ -36,6 +39,17 @@ def _decay_rate() -> float:
         return max(dyn.decay_rate, 1e-9)
     except Exception:  # pragma: no cover - settings module optional
         return 30.0
+
+
+def _is_dev_mode() -> bool:
+    """Return ``True`` when running in development profile."""
+    try:  # Lazy import to avoid heavy deps at import time
+        from memory_system.config.settings import get_settings
+
+        cfg = get_settings()
+        return getattr(cfg, "profile", "") == "development"
+    except Exception:  # pragma: no cover - settings module optional
+        return False
 
 
 @dataclass
@@ -77,8 +91,19 @@ class MemoryDynamics:
     # Scoring helpers
     # ------------------------------------------------------------------
 
-    def score(self, memory: Memory, *, now: dt.datetime | None = None) -> float:
-        """Return the ranking score for *memory* with intensity decay."""
+    def score(
+        self,
+        memory: Memory,
+        *,
+        now: dt.datetime | None = None,
+        return_parts: bool = False,
+    ) -> float | tuple[float, dict[str, float]]:
+        """Return the ranking score for *memory* with intensity decay.
+
+        When ``return_parts`` is ``True`` the individual weighted components
+        are returned alongside the final score as ``(score, parts)`` where
+        ``parts`` is a mapping of component name to its contribution.
+        """
         valence_weight = self.weights.valence_pos if memory.valence >= 0 else self.weights.valence_neg
         imp = max(0.0, min(1.0, memory.importance))
         inten = max(0.0, min(1.0, memory.emotional_intensity))
@@ -89,7 +114,29 @@ class MemoryDynamics:
         age_days = max(0.0, (now - last).total_seconds() / 86_400.0)
         decay = math.exp(-age_days / _decay_rate())
         inten *= decay
-        return self.weights.importance * imp + self.weights.emotional_intensity * inten + valence_weight * val
+
+        imp_part = self.weights.importance * imp
+        inten_part = self.weights.emotional_intensity * inten
+        val_part = valence_weight * val
+        score = imp_part + inten_part + val_part
+
+        if _is_dev_mode():
+            log.debug(
+                "score parts for %s: importance=%.3f, intensity=%.3f, valence=%.3f -> %.3f",
+                memory.id,
+                imp_part,
+                inten_part,
+                val_part,
+                score,
+            )
+
+        if return_parts:
+            return score, {
+                "importance": imp_part,
+                "emotional_intensity": inten_part,
+                "valence": val_part,
+            }
+        return score
 
     @staticmethod
     def _last_accessed(memory: Memory) -> dt.datetime:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -562,6 +562,17 @@ class TestMemoryEndpoints:
         )
         assert resp_weighted.json()[0]["text"] == "bad but vital"
 
+    def test_best_memories_score_parts_dev(self) -> None:
+        """score_parts flag should return breakdown in development profile."""
+        settings = UnifiedSettings.for_development()
+        app = create_app(settings)
+        with TestClient(app) as client:
+            client.post("/api/v1/memory/", json={"text": "hello"})
+            resp = client.get("/api/v1/memory/best", params={"score_parts": True})
+            assert resp.status_code == 200
+            payload = resp.json()
+            assert "score_parts" in payload[0]
+
 
 class TestErrorHandling:
     """Test error handling."""


### PR DESCRIPTION
## Summary
- log individual score components when computing memory ranking in development profile
- optionally return weighted score breakdown via `/memory/best` using `score_parts` flag
- add regression test for score breakdown API

## Testing
- `pytest tests/test_api.py::TestMemoryRoutes::test_best_memories_endpoint tests/test_api.py::TestMemoryRoutes::test_best_memories_score_parts_dev -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68974787e9a883259b62ad64e49f4baf