### PR TITLE
feat: guard optional dependencies

### DIFF
--- a/embedder.py
+++ b/embedder.py
@@ -6,16 +6,52 @@ Provides ``embed`` function compatible with ``UnifiedSettings`` integration.
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING, Any
 
-import numpy as np
+try:  # optional numpy
+    import numpy as np
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    np = None  # type: ignore[assignment]
 
-from sentence_transformers import SentenceTransformer
+try:  # optional sentence-transformers
+    from sentence_transformers import SentenceTransformer
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    SentenceTransformer = None  # type: ignore[assignment]
 
-_model: SentenceTransformer = SentenceTransformer("all-MiniLM-L6-v2")
+if TYPE_CHECKING:  # pragma: no cover - typing helper
+    import numpy as _np
+
+_model: SentenceTransformer | None = None
 
 
-def embed(text: str | list[str]) -> np.ndarray:
+def _require_numpy() -> Any:
+    if np is None:
+        raise ModuleNotFoundError(
+            "numpy is required for local embeddings. Install ai-memory[embedder]."
+        )
+    return np
+
+
+def _require_sentence_transformers() -> Any:
+    if SentenceTransformer is None:
+        raise ModuleNotFoundError(
+            "sentence-transformers is required for local embeddings."
+        )
+    return SentenceTransformer
+
+
+def _get_model() -> Any:
+    global _model
+    if _model is None:
+        st = _require_sentence_transformers()
+        _model = st("all-MiniLM-L6-v2")
+    return _model
+
+
+def embed(text: str | list[str]) -> "_np.ndarray":
     """Return embeddings for ``text`` without external API calls."""
+    np = _require_numpy()
+    model = _get_model()
     if isinstance(text, str):
         text = [text]
 
@@ -23,12 +59,12 @@ def embed(text: str | list[str]) -> np.ndarray:
     log.info("Embedding batch size %d", len(text))
 
     if not any(text):
-        model_dim = _model.get_sentence_embedding_dimension()
+        model_dim = model.get_sentence_embedding_dimension()
         if len(text) == 1:
             return np.zeros(model_dim, dtype=np.float32)
         raise ValueError("text cannot be empty")
 
-    vecs = _model.encode(text)
+    vecs = model.encode(text)
     vecs = np.asarray(vecs, dtype=np.float32)
     norms = np.linalg.norm(vecs, axis=1, keepdims=True)
     norms[norms == 0] = 1.0

--- a/memory_system/cli.py
+++ b/memory_system/cli.py
@@ -19,8 +19,20 @@ from pathlib import Path
 from typing import Any, Optional, Type, cast
 
 # ────────────────────────────── third-party imports ────────────────────────────
-import httpx
+try:  # optional http client
+    import httpx
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    httpx = None  # type: ignore[assignment]
 import typer
+
+
+def _require_httpx() -> Any:
+    """Return httpx module or raise a helpful error."""
+    if httpx is None:  # pragma: no cover - runtime guard
+        raise ModuleNotFoundError(
+            "httpx is required for CLI operations. Install ai-memory[cli]."
+        )
+    return httpx
 
 Panel: Type[Any]
 Table: Type[Any]
@@ -109,7 +121,8 @@ DEFAULT_API = "http://localhost:8000"
 
 def _client(base_url: str) -> httpx.AsyncClient:  # noqa: D401
     """Return shared httpx client with reasonable timeout."""
-    return httpx.AsyncClient(base_url=base_url, timeout=30.0)
+    hx = _require_httpx()
+    return hx.AsyncClient(base_url=base_url, timeout=30.0)
 
 
 def _metadata_option(

--- a/memory_system/core/embedding.py
+++ b/memory_system/core/embedding.py
@@ -17,19 +17,45 @@ import logging
 import threading
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, cast, TYPE_CHECKING
 
-import numpy as np
+try:  # optional numpy
+    import numpy as np
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    np = None  # type: ignore[assignment]
+
+try:  # optional sentence-transformers
+    from sentence_transformers import SentenceTransformer
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    SentenceTransformer = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:  # pragma: no cover - typing helper
+    import numpy as _np
 
 from memory_system.config.settings import UnifiedSettings
 from memory_system.utils.cache import SmartCache
 from memory_system.utils.loop import get_or_create_loop
 from memory_system.utils.metrics import EMBEDDING_QUEUE_LENGTH, MET_ERRORS_TOTAL
-from sentence_transformers import SentenceTransformer
 
 __all__ = ["EmbeddingError", "EmbeddingJob", "EnhancedEmbeddingService"]
 
 log = logging.getLogger(__name__)
+
+
+def _require_numpy() -> Any:
+    if np is None:
+        raise ModuleNotFoundError(
+            "numpy is required for embedding services. Install ai-memory[embedding]."
+        )
+    return np
+
+
+def _require_sentence_transformers() -> Any:
+    if SentenceTransformer is None:
+        raise ModuleNotFoundError(
+            "sentence-transformers is required for embedding services."
+        )
+    return SentenceTransformer
 
 ###############################################################################
 # Exceptions & Data Containers
@@ -111,7 +137,8 @@ class EmbeddingService:
                 return
             try:
                 log.info("Loading embedding model: %s", self.model_name)
-                self._model = SentenceTransformer(self.model_name)
+                st = _require_sentence_transformers()
+                self._model = st(self.model_name)
                 log.info(
                     "Model loaded: %s (dim=%d)",
                     self.model_name,
@@ -123,7 +150,8 @@ class EmbeddingService:
                 if self.model_name != fallback:
                     try:
                         log.info("Attempting fallback model: %s", fallback)
-                        self._model = SentenceTransformer(fallback)
+                        st = _require_sentence_transformers()
+                        self._model = st(fallback)
                         self.model_name = fallback
                         log.info("Fallback model loaded: %s", fallback)
                     except Exception as fexc:
@@ -141,6 +169,7 @@ class EmbeddingService:
 
     def _batch_loop(self) -> None:
         """Background thread loop that processes queued embedding jobs in batches."""
+        np = _require_numpy()
         batch_size = self.settings.model.batch_add_size
         log.debug("Batch processor loop started (batch_size=%d)", batch_size)
         while not self._shutdown.is_set():
@@ -177,7 +206,7 @@ class EmbeddingService:
 
     # Public API
 
-    async def embed_text(self, text: str | Sequence[str]) -> np.ndarray:
+    async def embed_text(self, text: str | Sequence[str]) -> "_np.ndarray":
         """Return an embedding for the given text (string or sequence of strings)."""
         if isinstance(text, str):
             # Single text -> returns shape (1, dim) array
@@ -188,8 +217,9 @@ class EmbeddingService:
 
     # Internal async helpers
 
-    async def _embed_single(self, text: str) -> np.ndarray:
+    async def _embed_single(self, text: str) -> "_np.ndarray":
         """Embed a single string into a 1 x dim embedding vector (as numpy array)."""
+        np = _require_numpy()
         if not text:
             raise ValueError("text must not be empty")
         # Attempt cache lookup first
@@ -219,8 +249,9 @@ class EmbeddingService:
         self.cache.put(key, embedding)
         return embedding.reshape(1, -1)
 
-    async def _embed_multi(self, texts: list[str]) -> np.ndarray:
+    async def _embed_multi(self, texts: list[str]) -> "_np.ndarray":
         """Embed a list of texts into an array of embeddings."""
+        np = _require_numpy()
         # For multiple texts, we can process them directly (and possibly cache each)
         embeddings = []
         for text in texts:
@@ -229,8 +260,9 @@ class EmbeddingService:
         # Concatenate results into one array
         return cast(np.ndarray, np.vstack(embeddings))
 
-    def _embed_direct(self, texts: list[str]) -> np.ndarray:
+    def _embed_direct(self, texts: list[str]) -> "_np.ndarray":
         """Directly embed a batch of texts (runs in background thread)."""
+        np = _require_numpy()
         if self._model is None:
             raise EmbeddingError("Embedding model is not loaded")
         embedding = self._model.encode(texts)

--- a/memory_system/core/enhanced_store.py
+++ b/memory_system/core/enhanced_store.py
@@ -10,9 +10,23 @@ import time
 import uuid
 from contextlib import suppress
 from dataclasses import dataclass
-from typing import Any, AsyncIterator, Iterable, MutableMapping, Sequence, cast
+from typing import Any, AsyncIterator, Iterable, MutableMapping, Sequence, cast, TYPE_CHECKING
 
-import numpy as np
+try:  # optional numpy
+    import numpy as np
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    np = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:  # pragma: no cover - typing helper
+    import numpy as _np
+
+
+def _require_numpy() -> Any:
+    if np is None:
+        raise ModuleNotFoundError(
+            "numpy is required for EnhancedMemoryStore. Install ai-memory[core]."
+        )
+    return np
 
 try:
     from cryptography.fernet import Fernet
@@ -134,6 +148,7 @@ class EnhancedMemoryStore:
 
     async def rebuild_index(self) -> None:
         """Recreate FAISS index from all records in the metadata store."""
+        np = _require_numpy()
         if self._closed:
             raise RuntimeError("store is closed")
         self._reindexing = True
@@ -211,6 +226,7 @@ class EnhancedMemoryStore:
 
     def add_control_query(self, embedding: list[float], expected_ids: list[str]) -> None:
         """Register a control query used for recall monitoring."""
+        np = _require_numpy()
         vec = np.asarray(embedding, dtype=np.float32)
         self._control_queries.append((vec, set(expected_ids)))
 
@@ -278,6 +294,7 @@ class EnhancedMemoryStore:
         updated_at: float | None = None,
     ) -> Memory:
         """Add a memory entry to the database and index."""
+        np = _require_numpy()
         ts = created_at if created_at is not None else time.time()
         text_to_store = text
         if self.settings.security.encrypt_at_rest:
@@ -347,6 +364,7 @@ class EnhancedMemoryStore:
 
     async def add_memories_batch(self, items: Sequence[dict[str, Any]]) -> list[Memory]:
         """Add multiple memories with embeddings in one batch."""
+        np = _require_numpy()
         entries: list[tuple[str, Memory, np.ndarray]] = []
         for item in items:
             text = item["text"]
@@ -389,6 +407,8 @@ class EnhancedMemoryStore:
         batch_size: int = 100,
     ) -> int:
         """Stream memories into the store and index without full buffering."""
+
+        np = _require_numpy()
 
         async def _aiter(it: Iterable[dict[str, Any]] | AsyncIterator[dict[str, Any]]):
             if hasattr(it, "__aiter__"):
@@ -489,6 +509,7 @@ class EnhancedMemoryStore:
         list[Any]
             A list of memories (optionally paired with their distance).
         """
+        np = _require_numpy()
         # ANN search with over-sampling to improve recall
         vec = np.asarray(vector, dtype=np.float32)
         async with self._search_lock:

--- a/memory_system/core/faiss_vector_store.py
+++ b/memory_system/core/faiss_vector_store.py
@@ -1,10 +1,25 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Sequence
+from typing import Sequence, TYPE_CHECKING, Any
 
-import numpy as np
-from numpy.typing import NDArray
+try:  # optional numpy
+    import numpy as np
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    np = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:  # pragma: no cover - typing helper
+    from numpy.typing import NDArray
+else:
+    NDArray = Any
+
+
+def _require_numpy() -> Any:
+    if np is None:
+        raise ModuleNotFoundError(
+            "numpy is required for FaissVectorStore. Install ai-memory[core]."
+        )
+    return np
 
 from memory_system.config.settings import UnifiedSettings
 from memory_system.core.index import FaissHNSWIndex, MultiModalFaissIndex
@@ -55,7 +70,8 @@ class FaissVectorStore(VectorStore):
         return self._index
 
     # ------------------------------------------------------------------
-    def add(self, ids: Sequence[str], vectors: NDArray[np.float32], *, modality: str = "text") -> None:
+    def add(self, ids: Sequence[str], vectors: NDArray, *, modality: str = "text") -> None:
+        np = _require_numpy()
         arr = np.asarray(vectors, dtype=np.float32)
         if self._multimodal:
             self._index.add_vectors(modality, list(ids), arr)
@@ -64,18 +80,19 @@ class FaissVectorStore(VectorStore):
 
     def search(
         self,
-        vector: NDArray[np.float32],
+        vector: NDArray,
         *,
         k: int = 5,
         modality: str = "text",
         ef_search: int | None = None,
     ) -> tuple[list[str], list[float]]:
+        np = _require_numpy()
         vec = np.asarray(vector, dtype=np.float32)
         if self._multimodal:
             return self._index.search(modality, vec, k=k, ef_search=ef_search)
         return self._index.search(vec, k=k, ef_search=ef_search)
 
-    def update(self, ids: Sequence[str], vectors: NDArray[np.float32], *, modality: str = "text") -> None:
+    def update(self, ids: Sequence[str], vectors: NDArray, *, modality: str = "text") -> None:
         self.delete(ids, modality=modality)
         self.add(ids, vectors, modality=modality)
 

--- a/memory_system/core/hierarchical_summarizer.py
+++ b/memory_system/core/hierarchical_summarizer.py
@@ -13,9 +13,23 @@ vector index so they can participate in subsequent searches.
 
 from __future__ import annotations
 
-from typing import List, Sequence
+from typing import List, Sequence, TYPE_CHECKING, Any
 
-import numpy as np
+try:  # optional numpy
+    import numpy as np
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    np = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:  # pragma: no cover - typing helper
+    import numpy as _np
+
+
+def _require_numpy() -> Any:
+    if np is None:
+        raise ModuleNotFoundError(
+            "numpy is required for hierarchical summarisation. Install ai-memory[core]."
+        )
+    return np
 
 from embedder import embed as embed_text
 from memory_system.core.index import FaissHNSWIndex
@@ -23,12 +37,13 @@ from memory_system.core.store import Memory, SQLiteMemoryStore
 from memory_system.core.summarization import STRATEGIES, SummaryStrategy
 
 
-def _cos_sim(a: np.ndarray, b: np.ndarray) -> float:
+def _cos_sim(a: "_np.ndarray", b: "_np.ndarray") -> float:
     """Cosine similarity for two 1-D L2-normalised vectors."""
+    np = _require_numpy()
     return float(np.dot(a, b))
 
 
-def _cluster_embeddings(embeddings: Sequence[np.ndarray], threshold: float) -> List[List[int]]:
+def _cluster_embeddings(embeddings: Sequence["_np.ndarray"], threshold: float) -> List[List[int]]:
     """Greedy single-pass clustering.
 
     Returns a list of clusters where each cluster is a list of indices into
@@ -92,6 +107,7 @@ class HierarchicalSummarizer:
             return []
 
         texts = [m.text for m in mems]
+        np = _require_numpy()
         embeddings = embed_text(texts)
         if isinstance(embeddings, np.ndarray) and embeddings.ndim == 1:
             embeddings = embeddings.reshape(1, -1)

--- a/memory_system/core/index.py
+++ b/memory_system/core/index.py
@@ -25,10 +25,19 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from time import perf_counter
+from typing import Any, TYPE_CHECKING
 
 import faiss
-import numpy as np
-from numpy import ndarray as NDArray
+try:  # optional numpy
+    import numpy as np
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    np = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:  # pragma: no cover - typing helper
+    from numpy import ndarray as NDArray
+else:
+    NDArray = Any
+
 from prometheus_client import Gauge, Histogram
 
 from memory_system.utils.exceptions import StorageError
@@ -36,6 +45,14 @@ from memory_system.utils.metrics import prometheus_counter
 from memory_system.utils.rwlock import RWLock
 
 log = logging.getLogger(__name__)
+
+
+def _require_numpy() -> Any:
+    if np is None:
+        raise ModuleNotFoundError(
+            "numpy is required for FaissHNSWIndex operations. Install ai-memory[core]."
+        )
+    return np
 
 # ───────────────────── Prometheus collectors ─────────────────────
 _VEC_ADDED = prometheus_counter("ums_vectors_added_total", "Vectors added to ANN index")
@@ -185,6 +202,7 @@ class FaissHNSWIndex:
         that FAISS does not allocate memory or compute graph structures
         until the index actually contains data.
         """
+        np = _require_numpy()
         if not self._warmed_up and self.index.ntotal > 0:
             dummy = np.asarray([[0.0] * self.dim], dtype=np.float32)
             if self.space == "cosine":
@@ -197,6 +215,7 @@ class FaissHNSWIndex:
     @staticmethod
     def _to_float32(arr: NDArray) -> NDArray:
         """Ensure array is float32 dtype."""
+        np = _require_numpy()
         return arr.astype(np.float32, copy=False)
 
     def _string_to_int(self, s: str) -> int:
@@ -227,9 +246,9 @@ class FaissHNSWIndex:
             ``(M, ef_construction, ef_search)`` of the selected configuration.
         """
 
+        np = _require_numpy()
         if sample_vectors.size == 0:
             return (self.DEFAULT_HNSW_M, self.DEFAULT_EF_CONSTRUCTION, self.DEFAULT_EF_SEARCH)
-
         vecs = self._to_float32(np.asarray(sample_vectors))
         if vecs.shape[1] != self.dim:
             raise ANNIndexError(f"dimension mismatch: expected dim={self.dim}, got {vecs.shape[1]}")
@@ -292,6 +311,7 @@ class FaissHNSWIndex:
     # ─────────────────────── Mutators ────────────────────────
     def add_vectors(self, ids: Sequence[str], vectors: NDArray) -> None:
         """Add vectors with external string IDs."""
+        np = _require_numpy()
         if len(ids) != len(vectors):
             raise ANNIndexError("ids and vectors length mismatch")
         if vectors.shape[1] != self.dim:
@@ -359,7 +379,7 @@ class FaissHNSWIndex:
         batch_size: int = 1000,
     ) -> None:
         """Add vectors from an iterator without loading all data at once."""
-
+        np = _require_numpy()
         ids: list[str] = []
         vecs: list[NDArray] = []
         for _id, vec in iterator:
@@ -374,6 +394,7 @@ class FaissHNSWIndex:
 
     def _rebuild_from_vectors(self) -> None:
         """Reconstruct the FAISS index from vectors kept in memory."""
+        np = _require_numpy()
         metric = faiss.METRIC_INNER_PRODUCT if self.space == "cosine" else faiss.METRIC_L2
         if self.index_type in {"IVF", "IVFFLAT"}:
             quantizer = faiss.IndexFlatL2(self.dim) if metric == faiss.METRIC_L2 else faiss.IndexFlatIP(self.dim)
@@ -434,6 +455,7 @@ class FaissHNSWIndex:
 
     def remove_ids(self, ids: Iterable[str]) -> None:
         """Remove vectors by string IDs."""
+        np = _require_numpy()
         int_ids = [self._reverse_id_map.get(i) for i in ids if i in self._reverse_id_map]
         if not int_ids:
             return
@@ -470,6 +492,7 @@ class FaissHNSWIndex:
         ef_search: int | None = None,
     ) -> tuple[list[str], list[float]]:
         """Search for k nearest neighbors of a vector."""
+        np = _require_numpy()
         if vector.shape[-1] != self.dim:
             raise ANNIndexError(f"dimension mismatch: expected dim={self.dim}, got {vector.shape[-1]}")
 

--- a/memory_system/core/interfaces.py
+++ b/memory_system/core/interfaces.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Sequence
+from typing import Any, Sequence, TYPE_CHECKING
 
-import numpy as np
-from numpy.typing import NDArray
+try:  # optional numpy for typing
+    import numpy as np
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    np = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:  # pragma: no cover - typing helper
+    from numpy.typing import NDArray
+else:
+    NDArray = Any
 
 from memory_system.core.store import Memory
 

--- a/memory_system/core/maintenance.py
+++ b/memory_system/core/maintenance.py
@@ -14,9 +14,23 @@ from __future__ import annotations
 
 import asyncio
 import datetime as dt
-from typing import Dict, List, Sequence, Tuple
+from typing import Dict, List, Sequence, Tuple, TYPE_CHECKING, Any
 
-import numpy as np
+try:  # optional numpy
+    import numpy as np
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    np = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:  # pragma: no cover - typing helper
+    import numpy as _np
+
+
+def _require_numpy() -> Any:
+    if np is None:
+        raise ModuleNotFoundError(
+            "numpy is required for maintenance operations. Install ai-memory[core]."
+        )
+    return np
 
 from embedder import embed as embed_text
 from memory_system.core.hierarchical_summarizer import HierarchicalSummarizer
@@ -28,8 +42,9 @@ from memory_system.core.summarization import STRATEGIES, SummaryStrategy
 # ----------------------------- small utils -----------------------------
 
 
-def _cos_sim(a: np.ndarray, b: np.ndarray) -> float:
+def _cos_sim(a: "_np.ndarray", b: "_np.ndarray") -> float:
     """Cosine similarity for two 1D embeddings (assumed L2-normalized)."""
+    np = _require_numpy()
     return float(np.dot(a, b))
 
 
@@ -41,7 +56,7 @@ def _now_utc() -> dt.datetime:
 
 
 def cluster_memories(
-    embeddings: Sequence[np.ndarray],
+    embeddings: Sequence["_np.ndarray"],
     threshold: float = 0.83,
 ) -> List[List[int]]:
     """
@@ -98,6 +113,7 @@ def summarize_cluster(
     else:
         fn = strategy
 
+    np = _require_numpy()
     summary_text = fn(memories)
     avg_importance = float(np.mean([m.importance for m in memories]))
     avg_valence = float(np.mean([m.valence for m in memories]))
@@ -139,6 +155,7 @@ async def consolidate_store(
     """
     created: List[Memory] = []
     ids_to_remove: List[str] = []
+    np = _require_numpy()
     pending_adds: List[tuple[Memory, np.ndarray]] = []
 
     async for chunk in store.search_iter(

--- a/memory_system/core/vector_store.py
+++ b/memory_system/core/vector_store.py
@@ -30,11 +30,26 @@ import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal, cast, TYPE_CHECKING
 
 import faiss
-import numpy as _np
-from numpy.typing import NDArray
+try:  # optional numpy
+    import numpy as _np
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    _np = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:  # pragma: no cover - typing helper
+    from numpy.typing import NDArray
+else:
+    NDArray = Any
+
+
+def _require_numpy() -> Any:
+    if _np is None:
+        raise ModuleNotFoundError(
+            "numpy is required for vector store operations. Install ai-memory[core]."
+        )
+    return _np
 
 from memory_system.utils.exceptions import StorageError, ValidationError
 from memory_system.utils.rwlock import AsyncRWLock
@@ -206,19 +221,21 @@ class AsyncFaissHNSWStore(AbstractVectorStore):
 # ---------------------------------------------------------------------------
 # ––– Utility helpers –––
 # ---------------------------------------------------------------------------
-def _to_faiss_array(vectors: Sequence[Sequence[float]]) -> NDArray[_np.float32]:
+def _to_faiss_array(vectors: Sequence[Sequence[float]]) -> NDArray:
     """Convert a sequence of vectors to a 2-D float32 NumPy array."""
-    arr = cast(NDArray[_np.float32], _np.array(vectors, dtype=_np.float32))
+    np = _require_numpy()
+    arr = cast(NDArray, np.array(vectors, dtype=np.float32))
     if arr.ndim == 1:
         arr = arr.reshape(1, -1)
     return arr
 
 
-def _to_faiss_ids(ids: Sequence[str]) -> NDArray[_np.int64]:
+def _to_faiss_ids(ids: Sequence[str]) -> NDArray:
     """Map UUID strings to FAISS-compatible ``int64`` identifiers."""
+    np = _require_numpy()
     return cast(
-        NDArray[_np.int64],
-        _np.array([uuid.UUID(_id).int & ((1 << 64) - 1) for _id in ids], dtype=_np.int64),
+        NDArray,
+        np.array([uuid.UUID(_id).int & ((1 << 64) - 1) for _id in ids], dtype=np.int64),
     )
 
 
@@ -238,7 +255,7 @@ import threading
 import time
 from typing import Sequence as _Seq
 
-import numpy as np
+# numpy is optional; loaded lazily via _require_numpy
 
 
 class VectorStore:
@@ -261,6 +278,7 @@ class VectorStore:
     # ------------------------------------------------------------------
     def _validate_vector(self, vector: _Seq[float] | np.ndarray) -> NDArray[np.float32]:
         """Validate ``vector`` and convert it to ``np.float32`` array."""
+        np = _require_numpy()
 
         if isinstance(vector, np.ndarray):
             if vector.dtype != np.float32:
@@ -297,6 +315,7 @@ class VectorStore:
 
     def get_vector(self, vector_id: str) -> NDArray[np.float32]:
         """Return the stored vector for ``vector_id``."""
+        np = _require_numpy()
         with self._db_lock:
             row = self._conn.execute(
                 "SELECT offset FROM vectors WHERE id=?",


### PR DESCRIPTION
## Summary
- lazily import extras like httpx and numpy
- add `_require_*` helpers so optional features raise clear errors when missing
- guard core modules against absent NumPy

## Testing
- `pytest tests/test_embedder.py tests/test_cli.py tests/test_core.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy httpx -q` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68974fbabde48325b285da9bede15c8a