### PR TITLE
test: mark optional dependencies

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,6 +31,9 @@ from memory_system.api.schemas import (
 from memory_system.config.settings import UnifiedSettings
 
 
+pytestmark = [pytest.mark.needs_fastapi, pytest.mark.needs_httpx]
+
+
 @pytest.fixture
 def test_settings() -> UnifiedSettings:
     """Create test settings."""

--- a/tests/test_api_edge_cases.py
+++ b/tests/test_api_edge_cases.py
@@ -12,6 +12,9 @@ from memory_system.config.settings import UnifiedSettings
 from memory_system.core.store import lifespan_context
 
 
+pytestmark = [pytest.mark.needs_fastapi, pytest.mark.needs_httpx]
+
+
 @pytest_asyncio.fixture
 async def async_client() -> AsyncGenerator[httpx.AsyncClient, None]:
     app = FastAPI(lifespan=lifespan_context)

--- a/tests/test_benchmark_regression.py
+++ b/tests/test_benchmark_regression.py
@@ -8,9 +8,10 @@ pytest_asyncio is used for async fixtures.
 import asyncio
 from typing import Any, AsyncGenerator, Callable
 
-import numpy as np
 import pytest
 import pytest_asyncio
+
+np = pytest.importorskip("numpy")
 
 from memory_system.utils.loop import get_or_create_loop
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,8 @@ from memory_system.config.settings import UnifiedSettings
 
 runner = CliRunner()
 
+pytestmark = pytest.mark.needs_httpx
+
 
 def _patch_client(monkeypatch: pytest.MonkeyPatch, handler: httpx.MockTransport) -> None:
     """Patch the CLI HTTP client to use the given transport."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,9 +9,10 @@ from pathlib import Path
 from typing import AsyncIterator, Generator, Iterator
 from unittest.mock import patch
 
-import numpy as np
 import pytest
 import pytest_asyncio
+
+np = pytest.importorskip("numpy")
 
 from memory_system.config.settings import UnifiedSettings
 from memory_system.core.embedding import (

--- a/tests/test_db_invariants.py
+++ b/tests/test_db_invariants.py
@@ -6,8 +6,9 @@ Works with SQLite or SQLCipher.
 from pathlib import Path
 from types import SimpleNamespace
 
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy")
 
 from memory_system.config.settings import DatabaseConfig, UnifiedSettings
 from memory_system.core.enhanced_store import EnhancedMemoryStore

--- a/tests/test_e2e_fastapi.py
+++ b/tests/test_e2e_fastapi.py
@@ -5,6 +5,8 @@ from fastapi.testclient import TestClient
 
 from memory_system.api.app import create_app
 
+pytestmark = [pytest.mark.needs_fastapi, pytest.mark.needs_httpx]
+
 
 @pytest.fixture()
 def client() -> Iterator[TestClient]:

--- a/tests/test_e2e_snapshot.py
+++ b/tests/test_e2e_snapshot.py
@@ -3,6 +3,7 @@ Adds a memory through REST, retrieves it, asserts round-trip integrity.
 Uses TestClient instead of HTTPX to stay in-process and fast.
 """
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -11,6 +12,9 @@ from memory_system.core.store import lifespan_context
 
 app = FastAPI(lifespan=lifespan_context)
 app.include_router(memory_router, prefix="/api/v1/memory")
+
+
+pytestmark = [pytest.mark.needs_fastapi, pytest.mark.needs_httpx]
 
 
 def test_add_and_get_memory() -> None:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -9,6 +9,9 @@ from memory_system.core.store import Memory, SQLiteMemoryStore
 from memory_system.core.vector_store import VectorStore
 
 
+pytestmark = [pytest.mark.needs_fastapi, pytest.mark.needs_httpx]
+
+
 @pytest.mark.asyncio
 async def test_sqlite_store_large_volume(tmp_path: Path) -> None:
     """Store and retrieve a large number of memories."""

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -1,7 +1,8 @@
 import logging
 
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy")
 
 from embedder import _model, embed
 

--- a/tests/test_enhanced_store.py
+++ b/tests/test_enhanced_store.py
@@ -11,9 +11,10 @@ import secrets
 import time
 from typing import AsyncGenerator
 
-import numpy as np
 import pytest
 import pytest_asyncio
+
+np = pytest.importorskip("numpy")
 
 from memory_system.config.settings import RankingConfig, UnifiedSettings
 from memory_system.core.enhanced_store import EnhancedMemoryStore

--- a/tests/test_enhanced_store_impl.py
+++ b/tests/test_enhanced_store_impl.py
@@ -1,8 +1,9 @@
 import os
 from pathlib import Path
 
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy")
 
 from memory_system.config.settings import UnifiedSettings
 from memory_system.core.enhanced_store import EnhancedMemoryStore

--- a/tests/test_fastapi_memory.py
+++ b/tests/test_fastapi_memory.py
@@ -12,6 +12,9 @@ from memory_system.api.routes.memory import router as memory_router
 from memory_system.core.store import SQLiteMemoryStore, lifespan_context
 
 
+pytestmark = [pytest.mark.needs_fastapi, pytest.mark.needs_httpx]
+
+
 @pytest.fixture
 def app(tmp_path: Path) -> FastAPI:
     """Create a FastAPI test application."""

--- a/tests/test_health_fault_injection.py
+++ b/tests/test_health_fault_injection.py
@@ -10,6 +10,8 @@ from fastapi.testclient import TestClient
 from memory_system.api.app import create_app
 from memory_system.config.settings import UnifiedSettings
 
+pytestmark = [pytest.mark.needs_fastapi, pytest.mark.needs_httpx]
+
 
 def test_index_missing_returns_503(monkeypatch: MonkeyPatch) -> None:
     """Test that health check returns 503 when ANN index is missing."""

--- a/tests/test_hierarchical_summarizer.py
+++ b/tests/test_hierarchical_summarizer.py
@@ -1,5 +1,6 @@
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy")
 
 import memory_system.core.hierarchical_summarizer as hs
 from memory_system.core.hierarchical_summarizer import HierarchicalSummarizer

--- a/tests/test_hypothesis_vectors.py
+++ b/tests/test_hypothesis_vectors.py
@@ -7,9 +7,10 @@ via an exact semantic search; the store must never raise or lose data.
 
 from typing import AsyncGenerator, List
 
-import numpy as np
 import pytest
 import pytest_asyncio
+
+np = pytest.importorskip("numpy")
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 from hypothesis.strategies import SearchStrategy

--- a/tests/test_index_persistence.py
+++ b/tests/test_index_persistence.py
@@ -1,5 +1,6 @@
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy")
 
 from memory_system.core.index import FaissHNSWIndex
 from memory_system.core.store import Memory, SQLiteMemoryStore, persist_index_on_commit

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -26,6 +26,9 @@ from memory_system.core.vector_store import VectorStore
 from memory_system.utils.security import EncryptionManager, EnhancedPIIFilter
 
 
+pytestmark = [pytest.mark.needs_fastapi, pytest.mark.needs_httpx]
+
+
 class TestEndToEndMemoryWorkflow:
     """Test complete end-to-end memory management workflow."""
 

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,9 +1,10 @@
 from typing import Sequence
 
-import numpy as np
 import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
+
+np = pytest.importorskip("numpy")
 
 from memory_system.core.index import FaissHNSWIndex
 from memory_system.core.maintenance import consolidate_store, forget_old_memories

--- a/tests/test_maintenance_hypothesis.py
+++ b/tests/test_maintenance_hypothesis.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-import numpy as np
 import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
+
+np = pytest.importorskip("numpy")
 
 from memory_system.core.index import FaissHNSWIndex
 from memory_system.core.maintenance import _decay_score, consolidate_store, forget_old_memories

--- a/tests/test_metrics_disabled.py
+++ b/tests/test_metrics_disabled.py
@@ -19,6 +19,9 @@ from memory_system.utils.metrics import (
 )
 
 
+pytestmark = [pytest.mark.needs_fastapi, pytest.mark.needs_httpx]
+
+
 @pytest.fixture(scope="session")
 def app_no_metrics() -> Any:
     cfg = UnifiedSettings.for_testing()

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -5,6 +5,7 @@ import inspect
 from types import SimpleNamespace
 from typing import Any, Awaitable, Callable, TypeVar, cast
 
+import pytest
 from fastapi import FastAPI, Request
 from starlette.responses import JSONResponse, Response
 
@@ -29,6 +30,9 @@ class _TestResponse:
 
 
 T = TypeVar("T")
+
+
+pytestmark = pytest.mark.needs_fastapi
 
 
 def create_app() -> FastAPI:

--- a/tests/test_multi_modality.py
+++ b/tests/test_multi_modality.py
@@ -1,5 +1,6 @@
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy")
 
 from memory_system.config.settings import UnifiedSettings
 from memory_system.core.enhanced_store import EnhancedMemoryStore

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -8,9 +8,10 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import AsyncGenerator, Generator, Iterable
 
-import numpy as np
 import pytest
 import pytest_asyncio
+
+np = pytest.importorskip("numpy")
 
 try:
     import psutil

--- a/tests/test_precision_at_k.py
+++ b/tests/test_precision_at_k.py
@@ -7,8 +7,9 @@ import random
 from pathlib import Path
 from typing import List, Union
 
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy")
 
 from memory_system.config.settings import UnifiedSettings
 from memory_system.core.enhanced_store import EnhancedMemoryStore

--- a/tests/test_reindexing.py
+++ b/tests/test_reindexing.py
@@ -7,6 +7,8 @@ from memory_system.api.app import create_app
 from memory_system.config.settings import UnifiedSettings
 from memory_system.core.enhanced_store import EnhancedMemoryStore
 
+pytestmark = [pytest.mark.needs_fastapi, pytest.mark.needs_httpx]
+
 
 @pytest.mark.asyncio
 async def test_add_blocks_during_reindexing():

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -5,6 +5,7 @@ import json
 import logging
 from types import SimpleNamespace
 
+import pytest
 from fastapi import FastAPI, Request
 
 from memory_system.api import app as app_module
@@ -29,6 +30,9 @@ def _make_app(rate_limit: int = 2) -> FastAPI:
 
     app_module.get_store = _dummy_get_store
     return create_app(settings)
+
+
+pytestmark = pytest.mark.needs_fastapi
 
 
 def _run(

--- a/tests/test_semantic_search_benchmark.py
+++ b/tests/test_semantic_search_benchmark.py
@@ -17,7 +17,7 @@ from memory_system.utils.loop import get_or_create_loop
 # Skip benchmarks when pytest-benchmark is not installed
 pytest.importorskip("pytest_benchmark")
 
-import numpy as np
+np = pytest.importorskip("numpy")
 
 from memory_system.config.settings import UnifiedSettings
 from memory_system.core.enhanced_store import EnhancedMemoryStore

--- a/tests/test_store_error_conditions.py
+++ b/tests/test_store_error_conditions.py
@@ -1,7 +1,8 @@
 from unittest.mock import AsyncMock, patch
 
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy")
 
 from memory_system.config.settings import UnifiedSettings
 from memory_system.core.enhanced_store import EnhancedMemoryStore


### PR DESCRIPTION
## Summary
- skip numpy-dependent tests if numpy missing
- mark FastAPI and HTTPX tests with optional dependency markers

## Testing
- `pytest tests/test_embedder.py -q`
- `pytest tests/test_db_invariants.py -q`
- `pytest tests/test_api.py tests/test_cli.py tests/test_middlewares.py -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install fastapi httpx -q` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6897566819b48325b135eed99a25ff1d