### PR TITLE
Organize imports and format code

### DIFF
--- a/load_tests/high_volume.py
+++ b/load_tests/high_volume.py
@@ -11,15 +11,15 @@ import argparse
 import asyncio
 import random
 import string
-import time
-from typing import AsyncIterator
-from pathlib import Path
 import sys
+import time
+from pathlib import Path
+from typing import AsyncIterator
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from memory_system.core.store import Memory, SQLiteMemoryStore
 from memory_system.core.memory_dynamics import MemoryDynamics
+from memory_system.core.store import Memory, SQLiteMemoryStore
 from memory_system.unified_memory import list_best
 
 

--- a/ltm_bench/metrics.py
+++ b/ltm_bench/metrics.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from pathlib import Path
 import base64
 from enum import Enum
+from pathlib import Path
 
 
 class EncState(Enum):
@@ -11,9 +11,7 @@ class EncState(Enum):
     UNKNOWN = "unknown"
 
 
-def verify_encryption(
-    path: str | Path, *, scheme: str = "fernet", sample_lines: int = 64
-) -> EncState:
+def verify_encryption(path: str | Path, *, scheme: str = "fernet", sample_lines: int = 64) -> EncState:
     """Heuristically validate that a text-ish artifact contains encrypted content.
 
     - For ``'fernet'`` expects urlsafe-base64 and version byte ``0x80`` after decode.

--- a/ltm_bench/test_runner.py
+++ b/ltm_bench/test_runner.py
@@ -17,9 +17,7 @@ def ensure_no_pii(results: Iterable[str]) -> bool:
     return True
 
 
-def run_report(
-    index_path: str | Path, search_results: Iterable[str]
-) -> dict[str, object]:
+def run_report(index_path: str | Path, search_results: Iterable[str]) -> dict[str, object]:
     """Run security checks and return a small summary report.
 
     Parameters

--- a/memory_system/core/index.py
+++ b/memory_system/core/index.py
@@ -249,11 +249,7 @@ class FaissHNSWIndex:
         # Attempt to locate an IVF component hidden inside wrappers
         ivf_index = None
         try:
-            ivf_index = (
-                base_index
-                if isinstance(base_index, faiss.IndexIVF)
-                else faiss.extract_index_ivf(base_index)
-            )
+            ivf_index = base_index if isinstance(base_index, faiss.IndexIVF) else faiss.extract_index_ivf(base_index)
         except Exception:
             ivf_index = None
         if ivf_index is not None and not ivf_index.is_trained:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -30,7 +30,6 @@ from memory_system.api.schemas import (
 )
 from memory_system.config.settings import UnifiedSettings
 
-
 pytestmark = [pytest.mark.needs_fastapi, pytest.mark.needs_httpx]
 
 


### PR DESCRIPTION
## Summary
- Sort and organize imports across benchmark, test, and core modules.
- Apply Ruff formatting to maintain consistent style.

## Testing
- `python -m ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx', 'fastapi', 'pydantic', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68976e6729408325a63a5e6fa774dac2