### PR TITLE
Reorder test imports for linting

### DIFF
--- a/tests/test_faiss_hnsw_benchmark.py
+++ b/tests/test_faiss_hnsw_benchmark.py
@@ -2,16 +2,15 @@
 
 from __future__ import annotations
 
-import os
-
 import pytest
-
-pytestmark = pytest.mark.needs_faiss
 
 faiss = pytest.importorskip("faiss")
 np = pytest.importorskip("numpy")
 
+import os
 from bench.faiss_hnsw import run_benchmark
+
+pytestmark = pytest.mark.needs_faiss
 
 # Baseline timings in milliseconds with generous tolerance.
 BASE_BUILD_MS = 100.0

--- a/tests/test_forget_low_trust.py
+++ b/tests/test_forget_low_trust.py
@@ -4,7 +4,6 @@ np = pytest.importorskip("numpy")
 faiss = pytest.importorskip("faiss")
 if faiss.__name__.startswith("tests._stubs"):
     pytest.skip("faiss not installed", allow_module_level=True)
-
 from memory_system.core.maintenance import _decay_score, forget_old_memories
 from memory_system.core.store import Memory
 

--- a/tests/test_forget_pinned.py
+++ b/tests/test_forget_pinned.py
@@ -1,4 +1,3 @@
-import asyncio
 import datetime as dt
 
 import pytest

--- a/tests/test_forget_ttl.py
+++ b/tests/test_forget_ttl.py
@@ -1,9 +1,5 @@
 import datetime as dt
-
 import pytest
-
-from memory_system.core.maintenance import forget_old_memories
-from memory_system.core.store import Memory, SQLiteMemoryStore
 
 np = pytest.importorskip("numpy")
 
@@ -11,6 +7,9 @@ try:  # pragma: no cover - optional dependency
     from memory_system.core.index import FaissHNSWIndex
 except ImportError:  # pragma: no cover - optional dependency
     FaissHNSWIndex = None  # type: ignore
+
+from memory_system.core.maintenance import forget_old_memories
+from memory_system.core.store import Memory, SQLiteMemoryStore
 
 
 @pytest.mark.skipif(FaissHNSWIndex is None, reason="faiss not available")

--- a/tests/test_hierarchical_summarizer.py
+++ b/tests/test_hierarchical_summarizer.py
@@ -1,13 +1,13 @@
 import pytest
 
-import memory_system.core.hierarchical_summarizer as hs
-from memory_system.core.hierarchical_summarizer import HierarchicalSummarizer
-from memory_system.core.store import Memory
-
 np = pytest.importorskip("numpy")
 faiss = pytest.importorskip("faiss")
 if faiss.__name__.startswith("tests._stubs"):
     pytest.skip("faiss not installed", allow_module_level=True)
+
+import memory_system.core.hierarchical_summarizer as hs
+from memory_system.core.hierarchical_summarizer import HierarchicalSummarizer
+from memory_system.core.store import Memory
 
 pytestmark = pytest.mark.asyncio
 


### PR DESCRIPTION
Reordered imports and grouped optional dependency checks at the top of several test modules, including the FAISS benchmark.
Drop unused asyncio import.